### PR TITLE
Fix and extend simple_transfer.py for THIN/v2 format compatibility

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,67 @@
-# How to transfer your model from BluePyOpt to BasalGangliaData (using Snudda format)
+# Example on how to transfer models from BPO to snudda
+The easiest way to transfer models is to use the script:  
+**simple_transfer.py** 
 
-# BluePyOpt 
+The transfer script will look for and use either val_models.json, hall_of_fame.json or best_models.json with that priority.
+
+**v2 / THIN format is handled automatically.** If `config/parameters.json` is in the newer nested-dict format (v2), it is converted to the expected list format (v1) before transfer. Similarly, if the models file is a THIN-format dict with a `"models"` key, the list is extracted and section names are normalised (`axon`→`axonal`, `soma`→`somatic`) automatically. No extra flags are needed — the script detects the format and converts on the fly.
+
+If simple_transfer.py fails, use the below basic options at the bottom of the notebook.
+
+run commands in terminal or use the code below
+
+### Examples
+Transfer one model from *source* (-s) and store in *destination* (-d):  
+
+>python simple_transfer.py **-s** example_models/str-fs-model1/
+>                          **-d** Transfered_models/fs/str-fs-model1/
+
+To transfer all the models in a directory, use the below command:  
+
+>python simple_transfer.py **-s** example_models/ **-d** Transfered_models/  **-a**
+
+which will try to transfer all the example models and sort them into respective celltype directory (i.g. dspn and fs).  
+The sorting assumes that the model name is of the format /region-type-additional_info/, e.g. str-dspn-...  
+If this is not the case, the model will be skipped (see output for example_models/fs/model1).  
+
+Models that already exist in the output folder will also be skipped (as is the case below for the model transfered as a single model).
+
+In order to se all the options, run below command in a terminal:  
+
+>python simple_transfer.py -h
+
+The transfer is an automated version of the 3 options described below.
+
+Example scripts of actual transfers can be found in the **example_transfers** folder.
+
+The models can be vierified used using the functions in **verify_models.py** 
+
+## Verify transfer by simulation
+Below simulations will only work if the original model has hoc versions of the models stored in a subfolder named checkpoints.  
+
+Use command:
+
+> python verify_model.py -p example_models/str-dspn-model2/ -o Transfered_models/dspn/str-dspn-model2/ 
+
+where  
+-p is path to the reference model (BPO)  
+-o is the flag for the output model (transfered)  
+
+for all options use:
+
+> python verify_model.py -h
+
+Here direct comparison of simulations in the two setups is used to verify the transfer. Another way to verify models would be to compare the output of  
+
+>for sec in h.allsec():  
+>>    h.psection(sec=sec)  
+
+if the output of this command is identical for transfered and reference models, and the mechanisms are identical -> the models are idential
+
+
+## Below follows a detailed description of the underlying functions that simple_transfer are using
+
+## BluePyOpt 
 
 To create single multi-compartmental models, the lab utilizes [BluePyOpt](https://github.com/BlueBrain/BluePyOpt). The optimization is started using a collection of code* with the "set up" of the 
 optimization is done with the following code:
@@ -38,16 +99,16 @@ If the optimization is also tested on several different morphologies, a third fi
 
 *for more information on the optimization contact Alex Kozlov or Ilaria Carannante. 
 
-## Option 1: Give the path to specific files
+### Option 1: Give the path to specific files
 
-### Required files
+#### Required files
     Mandatory
-    * parameters.json
-    * mechanisms.json
+    * parameters.json  (v1 list format or v2 nested-dict format — both accepted)
+    * mechanisms.json  (not required when using v2 parameters — generated automatically)
     VERSION - either 1 or 2 or 2 + 3
         1. best_models.json (if you are using the direct output of the optimizer)
         2. hall_of_fame.json (if you have filtered the parameter sets against more validations)
-        3. val_models.json (if you  have varied the morphology used within the original optimization and hence have more morph-parameter combinations)
+        3. val_models.json (if you have varied the morphology used within the original optimization and hence have more morph-parameter combinations)
         
 The model optimisation could be a folder, containing the follow files and subdirectories:
 
@@ -65,9 +126,9 @@ For an example of the structure and contents of the files, see **BasalGangliaDat
 
 *Contact Alex Kozlov for more information   
 
-# The steps
+## The steps
 
-### Create your own notebook and copy-paste the code to perform each step individually or utilize the class TransferBluePyOptToSnudda. 
+#### Create your own notebook and copy-paste the code to perform each step individually or utilize the class TransferBluePyOptToSnudda. 
 
 The transfer has been divided into several steps.
 
@@ -88,7 +149,7 @@ Create directory for the model.
      BasalGanglia/data/neurons/newnucleus/new_celltype/new_model
 ```        
 
-### Add tools to your path
+#### Add tools to your path
 
 ```
 import sys
@@ -97,14 +158,14 @@ source = "where the Bluepyopt optimisation, with the structure described above"
 destination = "BasalGanglia/data/neurons/newnucleus/new_celltype/new_model"
 ```
 
-### Transfer mechanisms
+#### Transfer mechanisms
 
 ```
 from transfer.mechanisms import transfer_mechanisms
 transfer_mechanisms(source=source, destination=destination)
 ```
 
-### Transfer parameters
+#### Transfer parameters
 
 ```
 from transfer.parameters import transfer_parameters
@@ -113,7 +174,7 @@ transfer_parameters(source=source,
                             selected=True)
 ```
 
-### Transfer selected models from val_models.json
+#### Transfer selected models from val_models.json
 
 
 ```
@@ -121,7 +182,7 @@ from transfer.selected_models import transfer_selected_models
 transfer_selected_models(source=source, destination=destination)
 ```
 
-### Transfer morphologies
+#### Transfer morphologies
 
 ```
 from transfer.morphology import transfer_morphologies
@@ -130,7 +191,7 @@ transfer_morphologies(source=source,
                               selected=True)
 ```
 
-### Create the meta.json which combines all information on the model
+#### Create the meta.json which combines all information on the model
 
 ```
 from meta.create_meta import write_meta

--- a/examples/simple_transfer.py
+++ b/examples/simple_transfer.py
@@ -1,9 +1,10 @@
 
-import shutil, os, sys, argparse, glob
+import shutil, os, sys, argparse, glob, json, tempfile
 import recenter_morph as rcm
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "tools")))
 
 from transfer import SimpleTransfer as strans
+import transform_parameters_from_v2_to_v1 as _tconv
 
 '''
 if no arguments are given an example model will be transfered
@@ -15,7 +16,59 @@ if no arguments are given an example model will be transfered
 -use -a or --all to batch transfer all models in one directory
 
     $ python simple_transfer.py -s <source> -d <destination> -a 1
+
+v2 parameter format (nested dict) is detected automatically and converted to v1
+(list) before transfer. The models file may also be in THIN format (a dict with
+a "models" key); in that case the list is extracted and section names are mapped
+from the THIN convention (axon/soma) to the BluePyOpt convention (axonal/somatic).
 '''
+
+# Section-name mapping from THIN optimisation output to BluePyOpt sectionlist names
+_SECTION_MAP = {'.axon': '.axonal', '.soma': '.somatic'}
+
+
+def _is_v2_params(path):
+    """Return True if the parameters file uses the v2 nested-dict format."""
+    with open(path) as f:
+        data = json.load(f)
+    return isinstance(data, dict)
+
+
+def _normalize_section_names(models_list):
+    """Rename .axon -> .axonal and .soma -> .somatic in model parameter keys."""
+    result = []
+    for model in models_list:
+        new_model = {}
+        for k, v in model.items():
+            for old, new in _SECTION_MAP.items():
+                if k.endswith(old):
+                    k = k[:-len(old)] + new
+                    break
+            new_model[k] = v
+        result.append(new_model)
+    return result
+
+
+def _load_and_normalize_models(models_path):
+    """Load a models file and normalise it to a plain list with BluePyOpt section names.
+
+    Handles both the plain-list v1 format and the THIN format
+    {"models": [...], "version": ..., ...}.  Returns None when the file is
+    already a plain list with no section-name changes needed (so the original
+    file can be used directly).
+    """
+    with open(models_path) as f:
+        raw = json.load(f)
+
+    if isinstance(raw, dict):
+        models = raw.get('models', [raw])
+        return _normalize_section_names(models)
+
+    # Plain list – only rewrite if any key needs renaming
+    if any(k.endswith(('.axon', '.soma')) for m in raw for k in m):
+        return _normalize_section_names(raw)
+
+    return None  # already correct, no temp file needed
 
 def center_morphology(source_path):
     # loop over all swc files in the morphology folder of the source and checks that the morphology is centered
@@ -27,10 +80,10 @@ def center_morphology(source_path):
 def do_transfer(source_path, new_cell_path):
     # The morphology must be centered - check and center if not centered.
     center_morphology(source_path)
-    
+
     # create output dir (check for existence is done in prev stage)
     os.makedirs(new_cell_path)
-    
+
     files_in_folder = [f for f in os.listdir(source_path) if os.path.isfile(os.path.join(source_path, f))]
     if not len(files_in_folder):
         raise Exception('\n\nInput Error - the source directory is empty\n'
@@ -53,13 +106,55 @@ def do_transfer(source_path, new_cell_path):
         f = 'best_models.json'
     else:
         raise Exception(f'Neither of: val_models, hall_of_fame nor best_models exist in source: \n{source_path}')
-    
+
     print(f'\ntranfering source: \n\t{source_path} \nto destination \n\t{new_cell_path}')
     print(f'\nusing opt_file: {f}\n')
-    strans.SimpleTransfer(  source_path, 
-                            new_cell_path, 
-                            optimisation_result_file=opt_res,
-                            selected=selected, selected_models=selected_models)
+
+    params_file     = os.path.join(source_path, 'config', 'parameters.json')
+    params_override = None   # path to converted v1 params (temp file)
+    mech_override   = None   # dir containing converted mechanisms.json (temp dir)
+    models_override = None   # path to normalised models list (temp file)
+    tmp_dir         = None
+
+    try:
+        # ── v2 parameter detection and conversion ─────────────────────────────
+        if os.path.exists(params_file) and _is_v2_params(params_file):
+            print(f'Detected v2 parameter format; converting to v1 ...')
+            tmp_dir = tempfile.mkdtemp(prefix='simple_transfer_')
+            v1, m1  = _tconv.read_data(params_file)
+            params_override = os.path.join(tmp_dir, 'parameters.json')
+            mech_override   = tmp_dir
+            with open(params_override, 'w') as fp:
+                json.dump(v1, fp, indent=3)
+            with open(os.path.join(tmp_dir, 'mechanisms.json'), 'w') as fp:
+                json.dump(m1, fp, indent=3)
+            print(f'v1 parameters written to {params_override}')
+
+        # ── models-file normalisation (THIN format / section-name mapping) ────
+        actual_opt_res = opt_res or f'{source_path}/best_models.json'
+        if os.path.exists(actual_opt_res):
+            models = _load_and_normalize_models(actual_opt_res)
+            if models is not None:
+                if tmp_dir is None:
+                    tmp_dir = tempfile.mkdtemp(prefix='simple_transfer_')
+                models_override = os.path.join(tmp_dir, 'models_normalized.json')
+                with open(models_override, 'w') as fp:
+                    json.dump(models, fp, indent=4)
+                print(f'Normalised {len(models)} model(s) written to {models_override}')
+
+        strans.SimpleTransfer(
+            source_path,
+            new_cell_path,
+            optimisation_result_file=models_override or opt_res,
+            parameters_path_folder=params_override,
+            mechanisms_path_folder=mech_override,
+            selected=selected,
+            selected_models=selected_models,
+        )
+
+    finally:
+        if tmp_dir:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 def transfer_all(source_path, new_celltype_path, clean=False):

--- a/examples/transform_parameters_from_v2_to_v1.py
+++ b/examples/transform_parameters_from_v2_to_v1.py
@@ -1,0 +1,96 @@
+
+import json, os
+from collections import OrderedDict
+
+def read_data(fname):
+    v1 = [] # for parameter file
+    m1 = {} # for mechanisms file
+    
+    with open(fname, 'r') as f:
+        params_v2 = json.load(f)
+    
+    if 'global' in params_v2:
+        for key,value in params_v2['global'].items():
+            v1.append({ "param_name": key,
+                        "type": "global",
+                        "value": value})
+    
+    for key in params_v2.keys():
+        if key == 'global': continue
+        
+        # should this be implemented some other way? (e.g. by importing mechanims.json)
+        if key == 'axon':
+            region = 'axonal'
+        elif key == 'soma':
+            region = 'somatic'
+        else:
+            region = key
+        
+        m1[region] = []
+        
+        for mech, item in params_v2[key].items():
+            
+            if not mech == 'neuron_specific':
+                m1[region].append(mech)
+            
+            for p, i2 in item.items():
+                
+                param = i2
+                param["sectionlist"] = region
+                if mech == 'neuron_specific':
+                    param["param_name"] = p
+                else:
+                    param["param_name"] = f'{p}_{mech}'
+                    #param["mech"] = mech
+                    #param["mech_param"] = p
+                
+                # fix dist_type
+                if not param["dist_type"] == "uniform":
+                    param["dist"] = param["dist_type"]
+                    param["dist_type"] = "distance"               
+                
+                v1.append(param)
+    
+    return v1, m1
+            
+
+       
+
+
+if __name__ == '__main__':
+    
+    import argparse
+    
+    parser = argparse.ArgumentParser(description='Script converting model parameter(v1) in to v2')
+    parser.add_argument('-f','--infile', help='parameter file (.json)', default=False)
+    parser.add_argument('-s','--save', help='save new format to file?', action="store_true", default=False)
+    dargs, ip = parser.parse_known_args()
+    args = vars(dargs)
+    
+    if not args['infile']:
+        if ip:
+            # assume that the first argument is the infile
+            args['infile'] = ip[0]
+        else:
+            raise Exception('Argument error - missing parameter file.\n' 
+                           'Please add a parameter file.\n\n'
+                           'Either use the -f flag or add it as the first argument:\n'
+                           'python transform_parameters_to_v2.py -f path/to/parameters.json\n'
+                           'python transform_parameters_to_v2.py path/to/parameters.json')
+    
+    v1, m1 = read_data(args['infile'])
+    if args['save']:
+        with open('param_v1.json', 'w') as f:
+            json.dump(v1, f, indent=3)
+        with open('mechanisms_v1.json', 'w') as f:
+            json.dump(m1, f, indent=3)
+    else:
+        print(json.dumps(v1, indent=3))
+        print()
+        print(json.dumps(m1, indent=3))
+    
+        
+        
+    
+    
+    

--- a/tools/transfer/SimpleTransfer.py
+++ b/tools/transfer/SimpleTransfer.py
@@ -67,14 +67,15 @@ class SimpleTransfer:
 
     def transfer(self):
 
-
         transfer_mechanisms(source=self.source, direct_path=self.mechanisms_path_folder,
                             destination=self.destination)
-        transfer_parameters(direct_path_param=self.parameters_path_folder,
-                            direct_path_best_models=self.optimisation_result_file, destination=self.destination)
 
         if self.selected:
             transfer_selected_models(source=self.source, destination=self.destination, direc_path_selected=self.selected_models)
+
+        transfer_parameters(direct_path_param=self.parameters_path_folder,
+                            direct_path_best_models=self.optimisation_result_file, destination=self.destination,
+                            selected=self.selected)
 
         transfer_morphologies(direct_path_morph=self.morphology_path_folder,
                               destination=self.destination, selected=self.selected)

--- a/tools/transfer/parameters.py
+++ b/tools/transfer/parameters.py
@@ -131,14 +131,26 @@ def combine_hall_of_fame_with_optimisation_parameters(source=None, destination=N
         with open(os.path.join(destination, "temp", "selected_models.json"), "r") as f:
             selected = json.load(f)
 
-        # Filter the parameter sets which were parameter ids were finally selected
-        hall_of_fame_sets = [hall_of_fame_sets[int(k)] for k in selected.keys()]
+        sorted_par_keys = sorted(selected.keys(), key=lambda x: int(x))
+        max_par_index = max(int(k) for k in sorted_par_keys)
+
+        if max_par_index < len(hall_of_fame_sets):
+            # Par values are valid indices into hall_of_fame — filter to selected models
+            hall_of_fame_sets = [hall_of_fame_sets[int(k)] for k in sorted_par_keys]
+        # else: hall_of_fame was already pre-filtered to exactly the selected models;
+        # use positional mapping (i-th sorted par key → i-th hall_of_fame entry)
 
     '''
     Combination of parameter set and hall of fame parameters
     '''
 
     combined_parameters = combine_hall_of_fame_parameters(parameter_set, hall_of_fame_sets)
+
+    # Remap sequential keys (0,1,2,...) back to the original par indices from val_models.json
+    # so write_meta can match against selected_models.json
+    if isinstance(selected, dict):
+        orig_keys = sorted(selected.keys(), key=lambda x: int(x))
+        combined_parameters = {orig_keys[i]: v for i, v in enumerate(combined_parameters.values())}
 
     save_parameter_set(parameter_set=combined_parameters,
                        destination=temp_dir)


### PR DESCRIPTION
What this PR does                                                             
                                                                                
Commit 1 — 75fdb6e: Fix execution order in SimpleTransfer —                   
  transfer_selected_models must run before transfer_parameters so the           
  selected_models.json filter file exists when it is needed. Also handles       
  pre-filtered hall-of-fame files correctly.                                  

- Move transfer_selected_models before transfer_parameters so selected_models.json exists when combine_hall_of_fame_with_optimisation_parameters tries to read it
- Pass selected=self.selected to transfer_parameters so filtering is actually applied
- In combine_hall_of_fame_with_optimisation_parameters: when par values in val_models.json exceed the hall_of_fame size (pre-filtered hof), fall back to positional mapping instead of index-based filtering which caused IndexError
- Remap sequential combined-parameter keys back to original par indices so write_meta correctly matches p-hashes against selected_models.json

Commit 2 — ace73a2: Extend simple_transfer.py to transparently handle the v2  
  parameter format used in newer optimisations (e.g. THIN interneurons):
                                                                                
  - v2 parameter auto-detection: if config/parameters.json is a nested dict (v2 
  format) rather than a list (v1 format), it is converted to v1 on-the-fly via
  transform_parameters_from_v2_to_v1.read_data(). A mechanisms.json is generated
   from the same conversion. Both are written to a temp directory and cleaned up
   after transfer.
  - THIN-format models file: if the models file is a dict with a "models" key
  (as produced by THIN optimisation scripts) rather than a plain list, the inner
   list is extracted automatically.
  - Section-name normalisation: THIN model parameter keys use .axon/.soma; the  
  transfer pipeline expects .axonal/.somatic. Keys are renamed transparently    
  before the parameters are combined.
  - Adds transform_parameters_from_v2_to_v1.py (the converter script used       
  internally).                                                                  
   
  The original v1 code path is unchanged — all new logic is bypassed when the   
  source is already in standard format.
                                                                                
  Test plan       

  - Transferred a 6-model THIN TH+ interneuron set                              
  (md_20171011_cell_1_2_ChIN_TH_current_best) using v2 parameters.json and
  THIN-format hall_of_fame.json — 6 hashed parameter sets produced with no      
  unresolved bounds
  - Verify existing v1-format example models still transfer correctly