### PR TITLE
Lts prune

### DIFF
--- a/data/neurons/mechanisms/kaf_ms.mod
+++ b/data/neurons/mechanisms/kaf_ms.mod
@@ -56,14 +56,14 @@ ASSIGNED {
 STATE { m h }
 
 BREAKPOINT {
-     SOLVE states METHOD cnexp
-	   modulation_factor_g=hill(PKAci, mod_pka_g_min, mod_pka_g_max, mod_pka_g_half, mod_pka_g_hill)
-     modulation_factor_shift=hill(PKAci, mod_pka_shift_min, mod_pka_shift_max, mod_pka_shift_half, mod_pka_shift_hill)	   					 
-
-    : In Johanna's version gk depended on modDA, and modShift on modACh
+	: In Johanna's version gk depended on modDA, and modShift on modACh
+	modulation_factor_g=hill(PKAci, mod_pka_g_min, mod_pka_g_max, mod_pka_g_half, mod_pka_g_hill)
+    modulation_factor_shift=hill(PKAci, mod_pka_shift_min, mod_pka_shift_max, mod_pka_shift_half, mod_pka_shift_hill)	   					 
+	modShift = modulation_factor_shift
+    
+    SOLVE states METHOD cnexp
     gk = gbar*m*m*h*modulation_factor_g
-    modShift = modulation_factor_shift			     
-    ik = gk*(v-ek)
+    	ik = gk*(v-ek)
 }
 
 DERIVATIVE states {
@@ -80,7 +80,7 @@ INITIAL {
 
 PROCEDURE rates() {
     UNITSOFF
-    minf = 1/(1+exp((v-(-10+modShift))/(-17.7)))
+    minf = 1/(1+exp((v-(-9+modShift))/(-17.7)))
     mtau = 0.9+1.1/(1+exp((v-(-30))/10))
     hinf = 1/(1+exp((v-(-75.6))/11.8))
     htau = 14

--- a/data/neurons/striatum/lts/LTS_180118_morp_9862_updated_April2022/meta.json
+++ b/data/neurons/striatum/lts/LTS_180118_morp_9862_updated_April2022/meta.json
@@ -1,2017 +1,1583 @@
 {
-    "p047a6bb7": {
-        "mda52699c": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-		[
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]	    
-        }
-    },
-    "p08df4357": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p116c624b": {
-        "mf4ba6a4e": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p133df8e0": {
-        "m8ded5e00": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p1a0c46fe": {
-        "m8ded5e00": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p1cd5defe": {
-        "m8ded5e00": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                            3e-05
-                ]
-            ]
-        }
-    },
-    "p238d51d1": {
-        "mda52699c": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                            3e-05
-                ]
-            ]
-        }
-    },
-    "p266c7fb8": {
-        "mf4ba6a4e": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                            3e-05
-                ]
-            ]
-        }
-    },
-    "p272f9557": {
-        "mda52699c": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                            3e-05
-                ]
-            ]
-        }
-    },
-    "p290dc260": {
-        "mf4ba6a4e": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p295c50fd": {
-        "ma4dacccf": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                            3e-05
-                ]
-            ]
-        }
-    },
-    "p2ecc7334": {
-        "ma4dacccf": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p3011abd8": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p3762fe01": {
-        "ma4dacccf": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p3832aa3a": {
-        "m803558b5": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p3900bef0": {
-        "mda52699c": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p3bd3c4c7": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p3c6b5232": {
-        "ma4dacccf": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p3f21fd29": {
-        "mf4ba6a4e": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p3f9dfe00": {
-        "ma4dacccf": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p3fec806e": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p413c8889": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p426a988e": {
-        "ma4dacccf": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p47d379ce": {
-        "mf4ba6a4e": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p4d93b0c3": {
-        "m8ded5e00": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p53b70df2": {
-        "ma4dacccf": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p54dfea77": {
-        "m8ded5e00": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p57337648": {
-        "mf4ba6a4e": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p607c0a42": {
-        "mf4ba6a4e": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p664ecb6e": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p70874b2a": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p72cfe937": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p733ec61e": {
-        "mda52699c": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p793a3d75": {
-        "ma4dacccf": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p7e33f26e": {
-        "m803558b5": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p7e8d7d6f": {
-        "mda52699c": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p881c7f54": {
-        "m8ded5e00": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p8b1585a0": {
-        "mf4ba6a4e": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p8bcdee47": {
-        "m803558b5": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p96bb9239": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p973cbb84": {
-        "mf4ba6a4e": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "p9f9c331a": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pa44a3f3f": {
-        "mf4ba6a4e": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "paf75a0ec": {
-        "m265f1bc4": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var4.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pb5a5193d": {
-        "mda52699c": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pb7358f32": {
-        "mf4ba6a4e": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pb823efb9": {
-        "mda52699c": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pb8351fef": {
-        "m803558b5": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pbae91695": {
-        "ma4dacccf": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pbd0a2290": {
-        "m803558b5": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pc2d8a8e6": {
-        "mda52699c": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pc7c856c6": {
-        "m803558b5": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pcec5cf27": {
-        "m8ded5e00": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pd2b66278": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pd2ca4eaf": {
-        "m803558b5": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pda92cc47": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pdc4da746": {
-        "ma4dacccf": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pdd9466e2": {
-        "m8ded5e00": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pe268b744": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pe2b0b6c2": {
-        "ma4dacccf": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pe5eef847": {
-        "mda52699c": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pe675a3d7": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pf83691b7": {
-        "m872fbb26": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pfa505758": {
-        "m803558b5": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
-    },
-    "pfddd6423": {
-        "m265f1bc4": {
-            "input": {
-                "cortical_background": {
-                    "conductance": 5e-10,
-                    "frequency": 1.0,
-                    "generator": "poisson",
-                    "jitter": 0.0,
-                    "mod_file": "tmGlut",
-                    "num_inputs": 21,
-                    "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
-                    "correlation": 0.0,
-                    "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
-                    "type": "AMPA_NMDA"
-                }
-            },
-            "morphology": "lts_morp_9862_centered_no_axon_resampled-var4.swc",
-	    "axon_density": [
-                "xyz",
-                "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
-                [
-                    -0.0002,
-                    0.0009,
-                    -0.0001,
-                    0.0001,
-                    -3e-05,
-                    3e-05
-                ]
-            ]
-        }
+  "p047a6bb7": {
+    "mda52699c": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
     }
+  },
+  "p08df4357": {
+    "m872fbb26": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p116c624b": {
+    "mf4ba6a4e": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p133df8e0": {
+    "m8ded5e00": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p1cd5defe": {
+    "m8ded5e00": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p238d51d1": {
+    "mda52699c": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p266c7fb8": {
+    "mf4ba6a4e": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p272f9557": {
+    "mda52699c": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p295c50fd": {
+    "ma4dacccf": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p2ecc7334": {
+    "ma4dacccf": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p3011abd8": {
+    "m872fbb26": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p3762fe01": {
+    "ma4dacccf": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p3832aa3a": {
+    "m803558b5": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p3900bef0": {
+    "mda52699c": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p3c6b5232": {
+    "ma4dacccf": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p3f21fd29": {
+    "mf4ba6a4e": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p3f9dfe00": {
+    "ma4dacccf": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p413c8889": {
+    "m872fbb26": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p426a988e": {
+    "ma4dacccf": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p47d379ce": {
+    "mf4ba6a4e": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p4d93b0c3": {
+    "m8ded5e00": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p53b70df2": {
+    "ma4dacccf": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p54dfea77": {
+    "m8ded5e00": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p607c0a42": {
+    "mf4ba6a4e": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p664ecb6e": {
+    "m872fbb26": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p70874b2a": {
+    "m872fbb26": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p733ec61e": {
+    "mda52699c": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p793a3d75": {
+    "ma4dacccf": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p7e8d7d6f": {
+    "mda52699c": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p881c7f54": {
+    "m8ded5e00": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p8b1585a0": {
+    "mf4ba6a4e": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p8bcdee47": {
+    "m803558b5": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p973cbb84": {
+    "mf4ba6a4e": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "p9f9c331a": {
+    "m872fbb26": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "paf75a0ec": {
+    "m265f1bc4": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var4.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pb5a5193d": {
+    "mda52699c": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pb7358f32": {
+    "mf4ba6a4e": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var7.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pb823efb9": {
+    "mda52699c": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pb8351fef": {
+    "m803558b5": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pbae91695": {
+    "ma4dacccf": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pbd0a2290": {
+    "m803558b5": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pc2d8a8e6": {
+    "mda52699c": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pcec5cf27": {
+    "m8ded5e00": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pd2ca4eaf": {
+    "m803558b5": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pdc4da746": {
+    "ma4dacccf": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pdd9466e2": {
+    "m8ded5e00": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var3.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pe268b744": {
+    "m872fbb26": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var5.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pe2b0b6c2": {
+    "ma4dacccf": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var1.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pe5eef847": {
+    "mda52699c": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var2.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pfa505758": {
+    "m803558b5": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var0.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  },
+  "pfddd6423": {
+    "m265f1bc4": {
+      "input": {
+        "cortical_background": {
+          "conductance": 5e-10,
+          "frequency": 1.0,
+          "generator": "poisson",
+          "jitter": 0.0,
+          "mod_file": "tmGlut",
+          "num_inputs": 21,
+          "parameter_file": "$SNUDDA_DATA/synapses/striatum/M1RH_Analysis_190925.h5-parameters-LTS.json",
+          "correlation": 0.0,
+          "synapse_density": "1.15*0.05/(1+exp(-(d-30e-6)/5e-6))",
+          "type": "AMPA_NMDA"
+        }
+      },
+      "morphology": "lts_morp_9862_centered_no_axon_resampled-var4.swc",
+      "axon_density": [
+        "xyz",
+        "12*3000*1e12*( 0.25*exp(-(((x-200e-6)/100e-6)**2 + ((y-0)/50e-6)**2 + ((z-0)/30e-6)**2)) + 1*exp(-(((x-300e-6)/300e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/10e-6)**2)) + 1*exp(-(((x-700e-6)/100e-6)**2 + ((y-0)/15e-6)**2 + ((z-0)/15e-6)**2)) )",
+        [
+          -0.0002,
+          0.0009,
+          -0.0001,
+          0.0001,
+          -3e-05,
+          3e-05
+        ]
+      ]
+    }
+  }
 }

--- a/data/neurons/striatum/lts/LTS_180118_morp_9862_updated_April2022/parameters.json
+++ b/data/neurons/striatum/lts/LTS_180118_morp_9862_updated_April2022/parameters.json
@@ -1,18787 +1,14741 @@
 {
-    "p047a6bb7": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 231.30583791318895
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 4.892407148501944e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 5.631251630633644e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.893770178768896e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -55.22145019735641
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -58.36549732521405
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -55.78267987991468
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.791433325554313e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0778524416019118e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0012625847859632046
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.5482619674373649
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0025223346142260175
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0011351641174573
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.003152671290457874
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.6315542452261003
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.020876285313885266
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00016578952533081507
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.12256722626907722
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.04128789896684838
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.011460600781012886
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0371040642963544
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0001267728726623875
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.2716877396269697e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0004401300439450035
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.562325673789565e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.739369751081351e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.631748175473379e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.6557919909175216
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.5318200869893226
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.257398315989847
-        }
-    ],
-    "p08df4357": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 100.8456716795906
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.6659093682687458e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 2.7322112876326746e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.624392098243078e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -57.78259395320903
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -50.32003871500396
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -56.60510001800674
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.418193948223709e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.3878346213794693e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0028584257007045386
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.6542268971587598
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.004376569596803806
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8438403996032133
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.003371350802098536
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.3668611286442321
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.044035549186653665
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00012926129216501216
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.5482553302077212
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.13085026798943342
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.002522579274160024
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.07150467347863558
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.510017060420883e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.7843946523453015e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.509779395624342e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.786011152849621e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.1570196125841443e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.047445783282532e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.462092818228974
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.1203748278811343
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.983150105705048
-        }
-    ],
-    "p116c624b": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 126.60567851779828
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.0544821558493e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.313656551436832e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 1.5100404552435311e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -59.74232032336621
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -55.0756884671549
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -61.72321022085306
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 4.137300458824426e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0874066290948893e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.002199698873063134
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.254357274742394
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0010965163114506887
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.9911646482290447
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.004498562191753606
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.2020757883696946
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03118188163234835
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005654982889654925
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.44376869152113585
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.10556069920392874
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0011396912631415998
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.1596689081903952
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.5234026267150953e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.4264175102332356e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0001866875207464328
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.325181678712807e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.776228587884152e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.5103661520229304e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.4074711528594914
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.6676247055576003
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.149749405980891
-        }
-    ],
-    "p133df8e0": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 167.84614377311766
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.6031517053449656e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 2.928073722040766e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.146040400691563e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -50.79363157614061
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -55.06109064653132
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -56.629203527290336
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.5486561052530654e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1529510730076844e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0034926912514868158
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.1506507845763513
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0010691192351477282
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.989679934687903
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.00423342488216364
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.2531988099729756
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.04694300716659008
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00031590758363613365
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.32855119534321264
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.11802567471735012
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0010006750358637483
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0901351580973778
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.345771516728265e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.078003530179743e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0001978530213911813
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.464228050026216e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.5552766607616023e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.060956861543321e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.2941867825324396
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.156510308209689
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.757749165183952
-        }
-    ],
-    "p1a0c46fe": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 230.35085410007272
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 1.60683476335001e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 2.528098623897422e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 1.3663955700662327e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -51.634606931270795
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -58.68793808611305
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -51.88443950000538
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.3490634765193158e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.8619622861129765e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.003954334649987677
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.033683051359457795
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0012687894894419243
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.91782846508259
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.004104114889393614
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.9103286373348534
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03944057326191414
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.000579957272660935
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.7615834836918555
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.06887793423545571
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005888914349289322
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.030118325673024485
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00026832850669166857
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.5259623484340177e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00022239834838653976
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0001002506570809046
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.431383714134133e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.193759325899688e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.412541218794569
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.863413355520392
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.793873268218952
-        }
-    ],
-    "p1cd5defe": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 231.81709407923327
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 5.796739126782091e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.535957900883827e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.687799350075957e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -52.216419803841724
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -57.144251492626054
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -61.7035774930251
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.5390445745380983e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.4162518019426431e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.003429894339997722
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.1692295404056592
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.002672699268561085
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.872638919448932
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0004877473072700722
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.8109154224803446
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.027790427397134027
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005651757794857418
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.7907871500913987
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.09221092103610148
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.004852361385509228
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0333146098714971
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00012990106003020268
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0757655960804841e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0001308186023531667
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00012417326540866287
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.7491623312669e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.7155811689645674e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.506995887985103
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.6996433232500223
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.941076878380217
-        }
-    ],
-    "p238d51d1": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 193.78369741784783
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.9235886394206025e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 5.762207062699177e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.726088050313856e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -63.41056926963998
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -55.02409164513228
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -61.49126478820329
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 4.580819694550943e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1510130494277939e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.005096799268973774
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.14034800710702547
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.003008135988671582
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.9033980367225327
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0019582659599972894
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.04609415723180735
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03997978832243735
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.2068115980370267e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.042346791736288164
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.055281948257842994
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.004317420120407321
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.053331706997149134
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0001300830772074299
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.8691596326172098e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0001646551220673128
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00014449360325965072
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00018715505192756229
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.196132051825392e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.169916415170221
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.264132469050038
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.899808267726857
-        }
-    ],
-    "p266c7fb8": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 209.11599365165858
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 8.637866043859393e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.197973938911308e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 1.639326288689838e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -56.26494348541581
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -62.11441805529206
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -63.65815545000523
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.348118329268998e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.24661222205305e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.003326070932844832
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.7715000369453321
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0030954068856757578
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8333693715790671
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0014658388027026974
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.8521900124315837
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.036258804353726866
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005678027896696057
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.041695756091508225
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.06765139891281721
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.005889228843314402
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.1078344892193629
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.000221587824379e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.235820906548204e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002972257619366535
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0001001273416561529
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.6671376269042372e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.2680536546836315e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.755894255191077
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.637881839597492
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.97401496009041
-        }
-    ],
-    "p272f9557": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 161.72209376731305
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.401462547157162e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 5.757930754552223e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.2859029577670155e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -63.93966494262719
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -51.48247925009903
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -62.95927042592041
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.938005325257127e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.235476782767892e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.002828213348991185
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.20764415879555928
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.002446186986838229
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0808953448964307
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0007063588706361751
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.6756726194912508
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.031724846965894525
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0004068060337468962
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.011266628919135727
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.1498374925350874
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0030649336877758932
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.05840771246313999
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002269140490674832
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.6247905565216034e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.719441908776847e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.416526849399812e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00011925314048162022
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.4467383318984896e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.195129593044268
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.8599997665889005
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.871648831685337
-        }
-    ],
-    "p290dc260": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 120.50212026942079
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.0950466549075152e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.4990985830687953e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.333023680707693e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -64.98051257952379
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -61.186395097384455
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -59.59334313854793
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.739900249952182e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.515194638035716e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00431327267978458
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.2972825361719828
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0025504231739754907
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8582073905373561
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.00468181052678657
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.73805576426721
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03859089675015805
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006453665109860127
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.01657932357818382
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.04496305155010663
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.004598547559119288
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.012305724384603756
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002606422618990727
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.599443309183655e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00024772593411527354
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.573336881625101e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.6332174910665733e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.925205565023292e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.473290750895335
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.5558096327821405
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.867346503512915
-        }
-    ],
-    "p295c50fd": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 174.06630671340744
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 1.8868562868992476e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.359074526609173e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 5.324560677194041e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -51.33272348163413
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -60.3043102635609
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -63.25919853052243
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.2072056584245579e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.177998286864517e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0020887311055646416
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.7518225834778763
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0025567050175466233
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8356233187561414
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.004301680671115705
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.7840416819901397
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0396580489455805
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00041189205315068114
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0011923782061789995
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.07840837600739936
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0025215390321394427
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.04083136616970007
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.000172727699241362
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.9135542171161053e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002853480421352556
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.92263843017311e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.457707019650924e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.6956857300058836e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.8348721547960483
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.7931943075011154
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.929605114409878
-        }
-    ],
-    "p2ecc7334": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 216.49322084101215
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.970473136259231e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 1.3156707260667564e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 1.0899433553568706e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -52.195252925297794
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -54.98939709378788
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -53.649583397513744
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.83785299195183e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.344411683626742e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.004477410021782247
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.2545644683239969
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0023470774235224605
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8697496464943506
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0024399664781545117
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.8384982830533437
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.027285279059788954
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00046427353826494056
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.07856182207362594
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.115996491858852
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.005471007811121647
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.018003978189204482
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00018905601337612584
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.6466608841556782e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0003422400281951232
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.016787968877389e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.3986136283503177e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.553473454419172e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.246582159126737
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.910361563842829
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.210508710086246
-        }
-    ],
-    "p3011abd8": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 177.26067487719732
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.00359048150204e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 1.1808037904942664e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.47649523551209e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -58.928408207290786
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -60.201358948392446
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -58.95088003378417
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.7002481225185036e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.007119814012947e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0006955288069174008
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.4962038101406397
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0018928648449763141
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.9071200217386012
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.007985172747546516
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.47253164973608375
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.057678487162118736
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0003584061822460628
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.28795248193821005
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0833751191492564
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0015189820317416643
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.03489841979667767
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.166808186507615e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.365118856363315e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0004867064304291735
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.078167853707455e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.6215922821253437e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.006178038920729e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.4834139245954754
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.776694110563395
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.952223435602309
-        }
-    ],
-    "p3762fe01": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 239.4844289280548
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 5.7780879676859695e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 1.702516314470078e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 5.507211259295937e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -55.54203026544929
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -50.2581877353665
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -51.301508464344174
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.0295616165934917e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.0117131245566683e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.004013591515881199
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.2596431217422932
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0036388439205302194
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0164936680445322
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0015819795247434699
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.37494765609997954
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0653120501861458
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00020623676759455012
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.18286082797962805
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.08872135350964039
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006787489268166311
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.3189132158031902
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 4.717765758525127e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.314030933207086e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00015983338471558275
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1532699845868924e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.288164226131608e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.0609154055754106e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.900937238802539
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.588833060923693
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.2126356210373785
-        }
-    ],
-    "p3832aa3a": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 153.71370353547866
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 4.047738053754601e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.810204257887845e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 7.320543649412045e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -61.277483687876526
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -63.026073853421444
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -53.97634165466346
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.892329798095484e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.2753654146692465e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002623849559315408
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.2300743721046564
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0013727984809215543
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.3962997212949229
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0008968580139010508
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 1.1392944959977107
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.057759780881637725
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00016480357546550775
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.63087319224479
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.08178352215032778
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005002652301138574
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.2018223097723821
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00014139194072054694
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.0471041637420682e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002529226777835903
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.4063017207722738e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.079131371853354e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.955088074241099e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.362184724536748
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.589437851914476
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.986709070348741
-        }
-    ],
-    "p3900bef0": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 219.88203214603948
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 4.429372599507232e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.1358094383190544e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.542458106071652e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -51.07273089920358
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -51.36507910269975
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -63.49150652494091
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.1444277843568508e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1333185594679612e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0021519285234675653
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.6996179932607756
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0036204691674715335
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.7737464054458136
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.00332972177300941
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.03128130519813268
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0531352550441991
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.746620736948345e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.007691247054120016
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.07896788143137431
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.003147468939791745
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.2643302747825632
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.551911512812685e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.8065117081910774e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00021089971022236062
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.750945132080978e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.0619716351132164e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.098642348854787e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.033998753544455
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.689472852724012
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.955568661963334
-        }
-    ],
-    "p3bd3c4c7": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 205.9613380000483
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.956712573845215e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.010300532581581e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.1445947401321057e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -58.0326963574942
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -63.45075064120129
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -64.5846657383746
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 4.44153196113304e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1972506318945516e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0032235513550660693
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.40464057782527696
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.003983280641782074
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.6484747191803346
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.005492553215758391
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.9179157408133581
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03979836842989068
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00045991330031289147
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.045975272917118164
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.05090190571061534
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0012668655831260824
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.07048630820972053
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00015200270117529845
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.9959815078288835e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00022461330618270248
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.974132457255711e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.7315515127402364e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.049893462107084e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.2960907668902815
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.0834902811294485
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.948972561503832
-        }
-    ],
-    "p3c6b5232": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 235.68584612109942
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.505464096946875e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.2619528868122227e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 1.6260570535180068e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -63.69223269360247
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -51.68153089333344
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -54.34698615410198
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.6231883669241736e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1349846862176738e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.004408826303328935
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.24548299496141915
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0015284185238058396
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.9743150008554627
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0047123465944475485
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.7102070419639162
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.02396947538271544
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005445302718583106
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.3764707926816472
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.18608628839230135
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005927008056279759
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.07476457214560134
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002423384719803278
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1404859383267543e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.505404293721551e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.881775317400968e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.5952539584264966e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.6367713773365356e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.0187018346383576
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.9384696606531726
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.846123819728993
-        }
-    ],
-    "p3f21fd29": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 204.92960332898238
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.5162888577899858e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.010421622008487e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.685275621384098e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -64.16742831149568
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -62.29423313455909
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -63.02389870940752
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.9493745748431046e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.4778798321529316e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00351126558858331
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.23686060239347703
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00313954248953957
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8186677123677062
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0031049662581791636
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.24195530674073956
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.037068464761187664
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006366575629958222
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.32712402358246406
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.05901838646959478
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0016258656819380989
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.011004979726182047
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002923113205658152
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.2568655645617684e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00020867110926875313
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.954655545326894e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.1474537013722416e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.920800373709121e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.870768825330431
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.917987013622582
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.852496235207445
-        }
-    ],
-    "p3f9dfe00": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 238.24252463034895
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 1.8151373511541313e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 1.8870313675191303e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.1999683876734857e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -50.12488055419261
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -61.19545539621967
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -62.64682064154896
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.0911463283164347e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.3288672022006437e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0011046575211057482
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.23332991154111626
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.002742629818062034
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8854832701002231
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0065672153730336
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.400871337583862
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.05351294663705183
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00020793111367390692
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.5516140510279098
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0777405725579994
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0010148311953175834
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.21841705604885822
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.471257433151794e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.3206322052697228e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0003835763423211719
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 9.008366044767562e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.714530663161207e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.004838163567653e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.419039549764532
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.678542930189005
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.995197469741035
-        }
-    ],
-    "p3fec806e": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 217.41876544720807
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 4.875576813602886e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.321573376440815e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.940483498208835e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -57.36319166642138
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -62.862478501021776
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -57.44144687202764
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.3637235829153984e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.750030547436491e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0031033965840133373
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.7397308473031051
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.002822608228170684
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.6749719840402043
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.005776575492182506
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.9362699147425947
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.039951415459919995
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.000349254702983401
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.6383930694197029
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.008524575756162575
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.001954199139789551
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.11672654791178322
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00013945823419269447
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.9926501533496854e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00010012124220577857
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.9442935051377084e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.12476595349264e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.8739416195333356e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.1128816823959435
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.008336996722599
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.981060073053045
-        }
-    ],
-    "p413c8889": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 208.42513962345717
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.6282449714680205e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.935746275356186e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.636945508405867e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -57.979586822835664
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -57.510496418567165
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -57.33468651952996
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.34125147277437e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.322302290536839e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.003421749281948434
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.7233412257952645
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0027753105470510477
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.7065861683270245
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0006452480616105115
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.2783664512897275
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03801065029295416
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00048053059800709806
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.09138449098979977
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.11088387313960421
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005493921854154409
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.1857578086323246
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002586402805907178
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.9864877232406038e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0001141126009344704
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00014213752457561637
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.74552709583313e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.3790513893299004e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.4819312841310395
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.7778472552110363
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.994625454125548
-        }
-    ],
-    "p426a988e": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 245.55283886577692
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 7.729568243215903e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.2799992463636287e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 6.70448416191253e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -54.12798313238953
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -50.36572250596699
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -60.1588080426228
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 9.474496251903907e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0280569983434704e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.005834233140776722
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.5406841215945414
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0019109491897194603
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.9060652529715595
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0008291412856904299
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.03485929686491602
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.033127671200490455
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0004500643522649261
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.26745910120653504
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.13432838038471537
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.004632817847512223
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.010386008228353158
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002702182871537082
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.686567230136421e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00025801476717493766
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.207806740020789e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.213615020129506e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.287558895549913e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.564511563281396
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.506240803189649
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.814857635305605
-        }
-    ],
-    "p47d379ce": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 242.42672896145743
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 4.898876219464227e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 1.9377952178165497e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 1.8619601006343426e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -55.01557654673226
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -59.98991165941392
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -52.60125717247327
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.356062832065951e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.7462133373767654e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.003711936305001542
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.5341567558920549
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.003921859693670682
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.5853589731218372
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.006911028006997994
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.2917893327928624
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03996895818766068
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00040528433447524384
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.10870903578495121
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.13458064716706525
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005963391419059349
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.012122611648043787
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00010530746693127019
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.932446753806756e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00015791813550977764
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00013295326911610394
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.958750890324405e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.435641515311738e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.0827413329389755
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.2707445431558146
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.9255304992100255
-        }
-    ],
-    "p4d93b0c3": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 205.5071924222691
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 5.312833102487853e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.528266263160924e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.665490809464613e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -51.89386266773975
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -52.515573643386574
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -60.90167105657953
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 4.757696644632377e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 9.313908660626442e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.003185499641657855
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.2153012962989918
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0015900920264030295
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0172857487284606
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.002923724394709657
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.6327420043880476
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03094413766636859
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006540451078200434
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.70884438458241
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.16415138490371295
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005000313747367297
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.041107161855476276
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.712946597075898e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.3769125797719807e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00045255088606203345
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.384772131269055e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.26017331007811e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.7605171423458694e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.504679794565409
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.6996433232500223
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.794533332572412
-        }
-    ],
-    "p53b70df2": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 166.99094425053045
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 6.238949366576495e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.0738531344797564e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.206962285626051e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -58.328300705850864
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -59.69458185350483
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -55.67259611090441
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.3242397289333012e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.324673541277788e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.001887346259135842
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.6375649727016094
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0021434283605584275
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8548898599586403
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.005242952789780568
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.6060866813476872
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.02834566411232433
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005503794139811539
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.039004005161798826
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.2040262571789958
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005569888035591884
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.09004088498125627
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00010734673675379312
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.9354649961844428e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.000487067878005804
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.9088150841412e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.812358929476095e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.0451445692641217e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.2488101481203375
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.308137689007586
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.868065626415208
-        }
-    ],
-    "p54dfea77": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 249.7530875160484
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 1.325432302634216e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 2.765782564633531e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 1.6288449457067968e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -61.34684559000189
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -64.5252081251757
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -50.991323647905396
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.241703289296832e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.254100346073058e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0032648075747005634
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.3042794948400466
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.003923208138024428
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.7246863432489115
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0037165597966035374
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.14089027101185495
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03787191035471798
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00037553415237502087
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.05127409191153495
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.06307903743134805
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.004094782554433689
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.041479767262105637
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.694497559445707e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.4039112408810316e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.203021139030961e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00010953214530549146
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.7786622200499858e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.392446551550593e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.756468719307047
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.5642532853739888
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.966134853669761
-        }
-    ],
-    "p57337648": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 112.77544437212282
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.401445661982812e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.082519039622816e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.4380951378245927e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -52.79816270885801
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -56.029558708607695
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -63.10916861546562
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.719324493842514e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0099746411818174e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0017312733493696996
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.1216709270393213
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0012039614273805976
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8812755021875133
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.007972861522691669
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.16856713730928957
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.02447082814769744
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005458757790689499
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.563208768010925
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.10766999751812535
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0010152258758627073
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.13956123564693934
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.424302384781887e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.40710861318117e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00037460390661182776
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.292176125900637e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.9458995039864512e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.003999688659195e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.0335915650089733
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.6285514540234365
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.756835619074369
-        }
-    ],
-    "p607c0a42": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 236.06329450008857
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.961570538152765e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.4160442508264295e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.553744124818341e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -56.225723795616155
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -57.78233930429548
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -64.14387350730064
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.3065670692857e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.158194204585139e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.000904809484451466
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.4391701632117695
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.001818490869394217
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.7821212173834065
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.005800126488463781
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.13566280468194147
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0398801499093925
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006199494059392198
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.397541304774491
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.09713065549704303
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005023246876278342
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0200541455782954
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00023064130378191167
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 9.561400073508419e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0003670255246403728
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.998042045124265e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.550440225593396e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.762291255187913e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.1430405737510223
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.7487267291888466
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.667416315360419
-        }
-    ],
-    "p664ecb6e": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 236.0278583108997
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 1.8471915630514548e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.1534886481996303e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 6.481561450233266e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -64.79173040830352
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -56.05931515919512
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -50.098371155256366
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.7343859986442034e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.006046622979112e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0010501773370998524
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.5221673113594366
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.002602551204049953
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8489016781375875
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.004679827288558785
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.39690055570195026
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.039385565148753736
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.000665863248158361
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.21647271353994507
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.08970935983505055
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0010607060258668267
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.15536454747445233
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00020917764768004122
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.8829499387205805e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00031343121828510313
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.951589143702572e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.296038920888227e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.662254936093092e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.0675171980553895
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.021163339056628
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.928941098293765
-        }
-    ],
-    "p70874b2a": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 245.75284079316188
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.9431216120679095e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 8.018925628191696e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 5.42441523940474e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -57.300758896723835
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -61.65435471491018
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -57.789311113176026
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.658069654654567e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.5679157784484126e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0007358854270357645
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.4581984566025348
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0021383325233764005
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.9089984402381881
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.009611910487140734
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.4380138835236888
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.05894112753367652
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00043291033614506176
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.3860938491394503
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.10580322930946727
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0010433559137212388
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.1180593881639008
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.611883712019207e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.2879282808948582e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.094315100534168e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.009678286444279e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.058901192838197e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.007377370385161e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.1804610621839458
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.323380838664491
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.933845783345152
-        }
-    ],
-    "p72cfe937": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 248.9230302485778
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 4.710312757615768e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 2.0675523501929148e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.2023485044055507e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -58.18626326496828
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -53.3119284162444
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -63.163206049091194
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.775841788195061e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.7527620190492467e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.005918326848963755
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.4484993363294231
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00324901757567321
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.7929440458793631
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0017264116143250513
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.5140227334264137
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03977240226037524
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006708189104307335
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.3431787425214054
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.09612490172656968
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0007888837659637419
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.03440175436967259
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00015299836456111415
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.4407605947254995e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00020416901641250444
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.038938612270926e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.35673603221828e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.243238622383143e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.761935573312124
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.186244292528363
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.692757386189362
-        }
-    ],
-    "p733ec61e": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 243.29089163779108
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 4.667467805309481e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.455984167191863e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 8.704735034151607e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -58.593516511998494
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -53.31558679427141
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -63.74883269551408
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 9.534613062999267e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1160124050438835e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.004568816402274764
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.011213188448117636
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00211474475183274
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.966704186437342
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.002806847860603429
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.5157382229264638
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.035461960870354206
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.825041288737908e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.47526217883321076
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.01819975123872751
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00938224425001414
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.011789855422834861
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.920250234584804e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.9790019957297984e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0003408746403468439
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.44305097246642e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 9.050070005782066e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.25367770462866e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.9090255703728434
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.041962097873483
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.821754501267114
-        }
-    ],
-    "p793a3d75": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 233.27524117644265
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 7.940745665094356e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.225308518727709e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 6.579879393862628e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -58.764627752232286
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -52.759693828728004
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -59.02319464564716
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.6757187525107487e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 9.458477949164466e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0024671059532274113
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.014039009374744262
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0035499015062385505
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.7751144558557123
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.004926676621124091
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0703404487507484
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.041974296919957015
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0003020655938379465
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.08596573995194601
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.06045468003901193
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.006425887219031761
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.01879603913966477
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.000277614702054179
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.128742682194442e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00043287994358593985
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.000105375640979571
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.241389692477458e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.0096017486162315e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.329110585006699
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.033583662732729
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.839074280802627
-        }
-    ],
-    "p7e33f26e": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 134.082698788865
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.414415132685747e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.034002633858289e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.060221378928558e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -50.87705988770981
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -50.01803945498702
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -58.21381309825286
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.7494325492346325e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0058003902562373e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.003997449581999307
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.505782667218214
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0020425072282831257
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8418970064498894
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.00856949411069551
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.6508240031088077
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.02193962464321934
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0004483533999062125
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.5792156213861557
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.1766271762608343
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0010581942150018064
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.02263821931746414
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.4267016364165735e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.6212254245374278e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0003758681077695975
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.3010037759627126e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.813596415332591e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.325132626484351e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.7280801964684174
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.977318394914442
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.994027285071667
-        }
-    ],
-    "p7e8d7d6f": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 211.97127046824573
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 1.5426733076499537e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.647525249188172e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.918001923750471e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -57.71824563296288
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -50.98693591765684
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -52.97655267568977
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.7508785341962122e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.000212934325115e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.004891659626897452
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.6982566312242874
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0010051612411152541
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.9775733743736108
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0017572691423282671
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.8735780010301352
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.032270485854828404
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.754944445588992e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.06362960359032308
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.10093258610331673
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0062247646801114566
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.01377427634433942
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 4.27308183114565e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.8512453860130757e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00022139292222584593
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.809139191838591e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.031048369997384e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.81938012009519e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.937317245883486
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.214119715830105
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.860805559790191
-        }
-    ],
-    "p881c7f54": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 192.1314421051553
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 4.7434451933563266e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 2.4424119529141585e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.0012411219039874e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -50.982908367521915
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -61.55909969179951
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -50.53445480431421
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.1284611729079334e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.0433990346994945e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00027932031576048737
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.04392882429019579
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0016323744786670025
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8711422678383155
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.004303950672327984
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.11062351104484575
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.023685096311372427
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.000565865814058391
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.279102706108537
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.152653829840793
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.004450467242207155
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.010568458006312636
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.751555664685602e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.108605020473204e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0001872147805925779
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00013882866133457095
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.7059705847432657e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.296577331945383e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.9555771729350018
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.081047217136987
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.694221145879086
-        }
-    ],
-    "p8b1585a0": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 162.5169566086368
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 1.682982366347911e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.238546633468376e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 5.003479458140164e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -60.63170482442454
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -57.01959443847233
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -51.48516747365744
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.2602837160013946e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.557746596357438e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.005155066492156156
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.4000610713582119
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.003158643527951664
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8683453665335238
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.002219712918781816
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.8175715127416003
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03872518179280909
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006183678974972455
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.042877378700417496
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.19686852988964954
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005033262013470278
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.13182486544204472
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00013546276275265025
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.3836360839448557e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00021191484135023642
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00010522985673812728
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.71304606142003e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.422550196551517e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.66097378222459
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.7445791954260974
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.992763409116858
-        }
-    ],
-    "p8bcdee47": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 249.03218550202664
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 5.016024767535336e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.828547879589919e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 8.526867223846131e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -62.4484747077091
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -63.88626113558711
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -60.23875750229095
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.406437850731641e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.1158465273718043e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.005084665968846306
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.12202396841424228
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.001875469694994828
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.218011812115499
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.006808196231262719
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.14776236274636906
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.059911252768913605
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00023533747859491694
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.7076174486426894
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.10430401004225581
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00488363570807552
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.04764697663217124
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.2601035782695295e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.865153914412216e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.000425327051019381
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 9.724113907109179e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.6530238234611654e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.56212456012246e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.9378256086476813
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.716334274440528
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.882302077002053
-        }
-    ],
-    "p96bb9239": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 245.73626436329124
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.134704075931809e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 1.105384646915949e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.9849228328152484e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -64.92376349195308
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -58.36905748383925
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -54.63569735575282
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.2623419146318066e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.2662294210504952e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.002871676083823833
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.5334395138214851
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0041706870070147345
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.6690100711307662
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0006604835176231324
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.7471704146374977
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03920846217309657
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00044092563135123415
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.14176332917154655
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.08462704659800432
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005413173485432672
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.041883277799025974
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00012999388823830543
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.526683456003309e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0001074418517612064
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.866119152757091e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.15292590352389e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.056121464085916e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.4295946993798196
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.500833632200415
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.637749372757165
-        }
-    ],
-    "p973cbb84": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 209.68132883250303
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 4.640701711988634e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 1.074337941246913e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.9576865358341564e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -61.27355200568813
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -56.88501991301351
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -62.64767331652581
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.166342253293483e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.389711601961898e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0005477910914731938
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.1474003187701044
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.002986912921929559
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.9289660741729003
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.004370847048216871
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.5883729931103099
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0372584877521146
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006488464578906942
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.07416727825274431
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.1797365934966424
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005668936990323852
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.01032640371626596
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.727053570071783e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.5232102919383368e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.258193945489443e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.802292001775548e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.364092279720513e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.648267556022183e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.950417930439239
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.361245654310595
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.933255132470486
-        }
-    ],
-    "p9f9c331a": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 248.58433057762022
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.770634593627686e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 1.0495454893544022e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 1.3072402370219923e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -55.21037454414803
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -59.0624145845982
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -64.81120282138018
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 9.097889180102015e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.5704013337889333e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0049144637257757485
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.5557055213870611
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0018278336222091734
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8095997443450221
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0019399960279598949
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.920507226694308
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03983263663164318
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005047315289250975
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.12370108537707544
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.10056248898149006
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005113034870659995
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.010565118846810972
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00014770089795565123
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.4693176600560782e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0003085521804373559
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.346637975475869e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.0415681740311613e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.241949547771107e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.722834863796742
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.2896944763410465
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.974374183722759
-        }
-    ],
-    "pa44a3f3f": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 118.37856581785022
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.8440827702463326e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 1.3206830260646758e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.061520524307074e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -61.529588423663874
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -64.91605169285957
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -58.01918421095741
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.3450156305481995e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.9940871529497574e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00396060273041052
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.10038996447518811
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0009709512761568455
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.95712723507037
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0016396193706794526
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.7852223025837789
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.04716115533435237
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00028731272016743395
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.13004335541038087
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.08031540794152214
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.003348899233710869
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.020150945542674253
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.267317872794199e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.0474360797535728e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00010973406365112551
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.64122227632492e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.7948287660188875e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.0008554696550885e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.142025237076476
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.474572545483513
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.93823674442693
-        }
-    ],
-    "paf75a0ec": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 218.14488916185
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 8.090348887766636e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 6.243325846923136e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 1.2465375181724995e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -64.95606493817044
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -50.87457186943515
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -63.04736174691005
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.540918443598773e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.821838000707072e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.004618270633021794
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03546277162843536
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.003520723890640903
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.9962698838513782
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.009978237678363967
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.2892433919435051
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.027187654632644283
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.818901329536638e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.24601374852935182
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.07614668950451581
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.002478955382898952
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0555272354075894
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.990515072629695e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.2476566081752982e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00010676328197911651
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.0177888210667075e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.187778594501607e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.13422939752369e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.466531966838427
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.700741290274458
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.666905671424436
-        }
-    ],
-    "pb5a5193d": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 143.3289296266067
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.378950065481207e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 5.778776319952232e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.797924806832736e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -61.65181828119879
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -50.60614063895329
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -58.963362597634514
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.4898399724161594e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.239408517748739e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00443600204147279
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.6017552512220897
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006463689743233368
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0867943077647764
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.002764020531660078
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.6859753053193588
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.018944541035276173
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00026028496632011274
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.24267214475191412
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.12581476385323553
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.008227991974868764
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.03423515693353614
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 9.069947922922382e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.8232290104964158e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002292660515884468
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.458330726181077e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.320994152336135e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.8119347842018735e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.2193725046427737
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.172636669708528
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.494148970185661
-        }
-    ],
-    "pb7358f32": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 199.59462689608762
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.771932809480327e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.3600388677056044e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.282099367283364e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -53.19084468500866
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -61.8578637200145
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -54.140774111855066
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.2159213959935132e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1729258187481597e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.004703455243925883
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.6556691004532577
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0037133538627422986
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.7284177128876219
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.005331358329824348
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.5192571494328765
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03657368510998042
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005851193377170639
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.05917687011243353
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.11929217254039094
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00050185310987465
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.09190209912193674
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00011782298884816233
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.2736958866843783e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00032858104159496797
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.3163714675940666e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.784506848786585e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.888804073690864e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.5625479310235186
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.802052627525108
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.9014413534180905
-        }
-    ],
-    "pb823efb9": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 217.1627248640853
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 4.244929642402819e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 6.3271960646659605e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.1770755594342287e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -53.77345792859441
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -55.28625226401164
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -56.399454884198384
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.8961555709018996e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.0380659656944676e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0021426188640218317
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.5127723647633885
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0018703370662527452
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1919836336587097
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0005821933766462697
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.6612937683910253
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.023314732333366426
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00042309790817610115
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.2767246825510667
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.18085380572140625
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.005084234864489817
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0160710512127541
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0001717341719519311
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.7366106845292765e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.000225204761900617
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.043774422691839e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.104425012174468e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.676687050477824e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.9876046043431277
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.5297164320913073
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.217250943353138
-        }
-    ],
-    "pb8351fef": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 209.1082253484168
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 4.777293939120539e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.028667495745563e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.705247151634762e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -61.58699930634991
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -58.051505883849636
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -50.01388024294325
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 4.721576525126374e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.120609544763178e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.005283853586837925
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.20753259367811494
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0019321079805675002
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.3468582135252942
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.006857194598662837
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.8503459949123735
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.06756429563505836
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0003080462519655259
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.24168227122707156
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.10183426445007851
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0008123890907023007
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.38371822701242453
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00012496798271869168
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.9123243460264898e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0004835243932648164
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.5997195573298225e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.7692082122104984e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.32573878602809e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.821665211764723
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.684342860332896
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.781102763712581
-        }
-    ],
-    "pbae91695": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 147.07277481428935
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 1.0846092934948414e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.216083833836945e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.061868132823717e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -56.518364099980076
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -53.12613721050264
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -51.87508937286412
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 4.224361399183333e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.909654320665866e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.004926450223914439
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.750346947796477
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0026726697280032704
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0088640973344294
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.004477445000835453
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.9741510435804684
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0293075599924432
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00029000333762424334
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.07022801901400588
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.09049208460156426
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.008116317806845694
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0734297224784124
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00010671533190084022
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.7549518153714115e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00040427265759250135
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.223355820951823e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.158303385031942e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.997838919953108e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.715518229904751
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.157881859566984
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.463772972066978
-        }
-    ],
-    "pbd0a2290": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 151.5414500542467
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 7.317348365733747e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.803664600280464e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 9.238635223293165e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -54.44375263008253
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -60.43640214451924
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -57.936007684360355
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.4840818275441692e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.6987709886497945e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0009711550579565005
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.43525160586508865
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0013727984809215543
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.3917476750946003
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0006089664842925053
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 1.095260891078238
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.043298399441648844
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00017031421694623194
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.1705794605049383
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0853542990760757
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0036319341651896778
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.11392801877963131
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.000281787570702929
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.101912440453475e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0003841253915936684
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0028975121889681e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.711203763830356e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.673657296649505e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.993261065550262
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.849088151067789
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.997175816858487
-        }
-    ],
-    "pc2d8a8e6": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 240.3403268419063
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.4912078680953616e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 5.735942657690736e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.229041617948554e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -54.18525335363716
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -51.11204906642077
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -63.85933327537786
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.5720930379734943e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.4093245473031877e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0009946884894328435
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.07202765778892076
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0009223486060543683
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0582674176911697
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0035739284576329373
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.47327615987406624
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.02809853871539879
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.482789943169264e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.13932479991266325
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.16878157021479512
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.003331187481555806
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.03763238385613256
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.987047270750738e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.6005176075208788e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0003187168276075825
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.0186215879932566e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.371811531388458e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.698052461888896e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.9930880976814613
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.225898136785797
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.988448158001654
-        }
-    ],
-    "pc7c856c6": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 179.7446369311596
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 1.542213880312454e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 5.546192605843146e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.5593526284467437e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -59.18509883612646
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -56.11332822967394
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -62.206034942753895
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.334709534495874e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.116819737677902e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.005876429105211956
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.3168202719016867
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.000620107049568175
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.7827120558794437
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.003174291751873069
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.39716185468258697
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03594308084474609
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00011409775758080359
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.3850669531825245
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.08946221580760697
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0044657714643911075
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.1461903658168567
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.683528502389831e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.6940101239482126e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00022092396642561904
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.8687267588500785e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 4.963218005961893e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.51163436843246e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.480300618827456
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.730845766560719
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.836465338625762
-        }
-    ],
-    "pcec5cf27": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 140.04813405191175
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.365076925328817e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.208293417197294e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.375244525181506e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -59.770599284430034
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -57.30516572343055
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -57.422850707816785
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.173744335910069e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 9.914256578866177e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0028682569726571857
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.3304699626526316
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.003066858646210989
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0134960183384762
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.005688434509082142
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.47809091434074835
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.016945111337537143
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006063079134942886
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.11052717089797531
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.13330567016276212
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.004475768782474634
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.010778435633372448
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.698136939582106e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.100657115132586e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00022618885207658135
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00013398379357403012
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.278413517698845e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.096238398427484e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.419248895354235
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.7515436771136046
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.576500671147623
-        }
-    ],
-    "pd2b66278": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 248.61799426643552
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.8050020898983405e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.4834144322998406e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.675331721989102e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -57.128922836951546
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -56.13281678396454
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -63.793528566159935
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.279248555057613e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.695667681754945e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.003537877546820752
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.7512368650558073
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.001977560901136341
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.7317426979573711
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.004108585555222066
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.5841484668061309
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03787097473700475
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006226223923793458
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.030563351367410785
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.13622731793831336
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.000500119358532959
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.02311311899746714
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00015112624825777622
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.7930721294056904e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00023297925191189704
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00011958165986865777
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.023549827848887e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.604728306107455e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.2148492729344285
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.9974833271681445
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.963355513815853
-        }
-    ],
-    "pd2ca4eaf": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 189.16578112875968
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 1.0754124274894497e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.0673570896045265e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.080310788062262e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -59.51874439506992
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -51.19286724146018
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -54.231358672798414
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 4.535012699556354e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 9.537523354305795e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0026766098050403867
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.48290569097136826
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0020257153215761737
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1699224135087227
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.005027540400301566
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.36491861630964695
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03371373454241298
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00020138668056037952
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.8989130376366874
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.012729363265733977
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.008809678557115173
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.04047351732099719
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00028575141265080106
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.5676079815600397e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00013110085470780062
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.004313063598955e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 6.373515431114219e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.039419511404722e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.6379046749616712
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.874449979890681
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.8525796942583534
-        }
-    ],
-    "pda92cc47": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 224.35711436923862
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.7847591976148975e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.502602524915709e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.2140887941248976e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -50.37084765792796
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -57.330686452410646
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -54.98774192026841
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.20629995338612e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.37654239551154e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.004438652824290528
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.6454594092611704
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.003052745400560684
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.7494617153762891
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0038868624067632707
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.36133363241842853
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.031419685725770835
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005292698290861594
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.2547308702553517
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.07680494035070035
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.000510780854382201
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.038022077728889395
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 9.670661827543159e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.2113756776217565e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0004228007295790982
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.752050917095151e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.2162220050587875e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0319740125498483e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.924355518273422
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.0572488595424896
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.291992832258733
-        }
-    ],
-    "pdc4da746": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 158.46068983204918
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.5331797677108154e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 5.084147376693514e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.0566162417120197e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -54.944993080500716
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -55.948300383777685
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -61.796728244010254
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.065726331976834e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.045808676126723e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00015266907862502275
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.5898606844216036
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.002295632898853408
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.885194675856526
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.003944960366425875
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.6397098160737706
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03908538205060942
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0002328795301513957
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.26843796221828825
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.14007491582554693
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.000541516205903076
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.05468025104207612
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.883888606308024e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.922996189159777e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.038508121761961e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.309220666071787e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 4.912149904479346e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 9.017822152840418e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.409283570644956
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.2135521167671106
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.920974668568739
-        }
-    ],
-    "pdd9466e2": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 248.3055725453828
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.1955040640472014e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.207819922548747e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 3.294841794775562e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -62.479810679210495
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -62.36473634538223
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -64.5229606945687
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.481641314130485e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.4650159958344181e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00013964679210602582
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.017158086889894605
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.004269278449121804
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.8342889314890003
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0023636513357812357
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.5623051871990516
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03429467031759474
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0005816290515307358
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.26467823919365846
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.08816433143547284
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0009649694682255397
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.013397406545001635
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002883233699019633
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.364657793205586e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002699887059287921
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.3983467559820005e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.599883581392195e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.149250718132517e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.504580407414203
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.3345219861936584
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.967290797933759
-        }
-    ],
-    "pe268b744": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 215.3823750840329
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 5.486033961723333e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.151574847286033e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.54485241691166e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -56.63438028823154
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -57.219371799406474
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -62.57631194956346
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.9919160279831505e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.162885343566659e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00048122174304864734
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.608273537282291
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0010214357952255454
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.9290969672417981
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0012426994620334392
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.8425795223056912
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03719710402734966
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006936313684876706
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.005987979406005029
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.10531345554172106
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0007276655268118904
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.12632891151660647
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00010308149154479495
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.8780917516556582e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0004488789507713211
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 6.063195881785738e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.0840664928317238e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.490563503673785e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 2.985685687184372
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.200094866798016
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.973401832577189
-        }
-    ],
-    "pe2b0b6c2": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 236.3276246353828
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.592886685547875e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 5.198220855132171e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 1.0684100094586486e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -63.944856958260345
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -61.574100173403856
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -64.70596840531444
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 5.642692045775671e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.722874636603369e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.005992042647309974
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.25580836758178555
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0021135329617064393
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.9893556258493281
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.005361782934285277
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.5753726891635674
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.027198219541348986
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006796568101108802
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.2663567384041597
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.09644987849167852
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.006862298559253169
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.04859593124796982
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0002228343054826654
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0505722088460623e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00020629178076852418
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00011128064278707044
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 3.5019311274750954e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 4.26704831945027e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.108630641843511
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.166134812520547
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.984738452407522
-        }
-    ],
-    "pe5eef847": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 148.20719006383885
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.5344205921502564e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 4.714143110281906e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 8.153680580687101e-07
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -52.36740750224596
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -53.9153452215797
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -50.21495965127834
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 9.695570692092593e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1068673021782574e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0030239863786351174
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.8498653189890477
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.001744943548452576
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.897994756915982
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.006621658300202202
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.17064107515047927
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.03043377167844748
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00017049652689548903
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0419356005923331
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.17041768143631125
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0013603899593371634
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.03152250643202818
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.835132639635039e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.426417138677814e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00011905099265513814
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.1246324111121e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.4826725569621762e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 7.170477390241508e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.5056288007303036
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.8191572191186927
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.749350526691023
-        }
-    ],
-    "pe675a3d7": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 208.90263832965573
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.0630499383079014e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.004686643151242e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 2.447195305081186e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -60.553425487401064
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -50.88609019111078
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -52.70390604308769
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 2.3938878941254506e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 9.094314055517471e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.004702823300818039
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.7930650807089135
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0011099034269648447
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.85352426779305
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0009178923536640814
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.6652148028497037
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.025315783727498938
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0006276480389247384
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.21546390983027752
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.16701138340661292
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.004787395079695377
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.03934230830966015
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00029231619016264473
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.4836879164489688e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00020609200764017403
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0001219680213522848
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.6227604774311308e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.651053269040108e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.4531892376997946
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.117115936063179
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.473072024332338
-        }
-    ],
-    "pf83691b7": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 226.0734562475244
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 2.9911899698808043e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 1.6559105871519309e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.7224183649084445e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -57.58170413198817
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -63.72712249339905
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -61.25829964620367
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.9197442430616397e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.3424943334509844e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.004171951043297996
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.7511322189806661
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0024064751436498237
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.6947529794373074
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.005415738930477202
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.039883781999116186
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.039657948313188446
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00041313735547730926
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.23254206543639555
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.007118998830822152
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.006145037349528797
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.013468159176949986
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00029041191569965724
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.2790670712460568e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00019910649594503808
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.756210848446118e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.4540177497281105e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.242254010436368e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.2075824398514974
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.77508086786728
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.85427583565393
-        }
-    ],
-    "pfa505758": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 237.717904827468
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 5.2209762619283945e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 3.5797542307335367e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 7.46779890446172e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -64.6676411978488
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -62.099423809509
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -54.11747590763021
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 1.0397891380779837e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.1363224168069096e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0034871193474999077
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.19759948960262183
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0034386601621204005
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.0446709749696557
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0010254579090168388
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 1.0429866240624575
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.06984364840778888
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0001161474152953279
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.2538700591169668
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.04586913370643004
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0023365649605742696
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.3380115773895607
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00015345468332640422
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.1453002053883494e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00035112947395971495
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.604588713077538e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 7.930170205049072e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 3.841848515480853e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.435120591681957
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.66494473140626
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.989249755235563
-        }
-    ],
-    "pfddd6423": [
-        {
-            "param_name": "celsius",
-            "type": "global",
-            "value": 35
-        },
-        {
-            "param_name": "v_init",
-            "type": "global",
-            "value": -84
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "cm",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 1
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ek",
-            "sectionlist": "all",
-            "type": "section",
-            "value": -100
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "ena",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 50
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "Ra",
-            "sectionlist": "all",
-            "type": "section",
-            "value": 204.79076349122244
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": 3.125626123990184e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": 6.020124935958089e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "g_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": 4.816770001764828e-06
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "somatic",
-            "type": "section",
-            "value": -60.08583115331678
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "basal",
-            "type": "section",
-            "value": -58.836241713043115
-        },
-        {
-            "dist_type": "uniform",
-            "param_name": "e_pas",
-            "sectionlist": "axonal",
-            "type": "section",
-            "value": -64.0204470153097
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 9.443778427566391e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "hd_lts",
-            "mech_param": "ghdbar",
-            "param_name": "ghdbar_hd_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 8.104457306152463e-07
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0008867998212908634
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.7920753745443823
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.001035031954936328
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.1034970488854507
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "na3_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_na3_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.0007104538678084676
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_naf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.7485879689973808
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.024803941093813685
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.00027649012346049124
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kdr_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.19158141125904382
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.14125429939765693
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 0.0023255609815144244
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "gkdrbar",
-            "param_name": "gbar_kaf_lts",
-            "sectionlist": "axonal",
-            "type": "range",
-            "value": 0.08123336504128985
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.00017228988423118903
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "im_lts",
-            "mech_param": "gkbar",
-            "param_name": "gkbar_im_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 1.4161364702094708e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 0.0004724382739564264
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "it_lts",
-            "mech_param": "gcabar",
-            "param_name": "gcabar_it_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 5.0588522879277424e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "somatic",
-            "type": "range",
-            "value": 8.5332338040763e-05
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kir23_lts",
-            "mech_param": "gbar",
-            "param_name": "gbar_kir23_lts",
-            "sectionlist": "basal",
-            "type": "range",
-            "value": 2.6226849627644127e-06
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "naf_lts",
-            "mech_param": "q",
-            "param_name": "q_naf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 3.372651265449332
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kaf_lts",
-            "mech_param": "q",
-            "param_name": "q_kaf_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.058126777554918
-        },
-        {
-            "dist_type": "uniform",
-            "mech": "kdr_lts",
-            "mech_param": "q",
-            "param_name": "q_kdr_lts",
-            "sectionlist": "all",
-            "type": "range",
-            "value": 4.289463138566104
-        }
-    ]
+  "p047a6bb7": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 231.30583791318895
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 4.892407148501944e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 5.631251630633644e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 3.893770178768896e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -55.22145019735641
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -58.36549732521405
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -55.78267987991468
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.791433325554313e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0778524416019118e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0012625847859632046
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.5482619674373649
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0025223346142260175
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0011351641174573
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.003152671290457874
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.6315542452261003
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.020876285313885266
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00016578952533081507
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.12256722626907722
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.04128789896684838
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.011460600781012886
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0371040642963544
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0001267728726623875
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.2716877396269697e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0004401300439450035
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.562325673789565e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 6.739369751081351e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.631748175473379e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.6557919909175216
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.5318200869893226
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.257398315989847
+    }
+  ],
+  "p08df4357": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 100.8456716795906
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.6659093682687458e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 2.7322112876326746e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 3.624392098243078e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -57.78259395320903
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -50.32003871500396
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -56.60510001800674
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.418193948223709e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.3878346213794693e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0028584257007045386
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.6542268971587598
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.004376569596803806
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8438403996032133
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.003371350802098536
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.3668611286442321
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.044035549186653665
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00012926129216501216
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.5482553302077212
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.13085026798943342
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.002522579274160024
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.07150467347863558
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.510017060420883e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.7843946523453015e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.509779395624342e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.786011152849621e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.1570196125841443e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.047445783282532e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.462092818228974
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.1203748278811343
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.983150105705048
+    }
+  ],
+  "p116c624b": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 126.60567851779828
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.0544821558493e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.313656551436832e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 1.5100404552435311e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -59.74232032336621
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -55.0756884671549
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -61.72321022085306
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 4.137300458824426e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0874066290948893e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.002199698873063134
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.254357274742394
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0010965163114506887
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.9911646482290447
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.004498562191753606
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.2020757883696946
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03118188163234835
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005654982889654925
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.44376869152113585
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.10556069920392874
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0011396912631415998
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.1596689081903952
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.5234026267150953e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.4264175102332356e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0001866875207464328
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.325181678712807e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 6.776228587884152e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.5103661520229304e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.4074711528594914
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.6676247055576003
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.149749405980891
+    }
+  ],
+  "p133df8e0": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 167.84614377311766
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 2.6031517053449656e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 2.928073722040766e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 4.146040400691563e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -50.79363157614061
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -55.06109064653132
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -56.629203527290336
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.5486561052530654e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1529510730076844e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0034926912514868158
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.1506507845763513
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0010691192351477282
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.989679934687903
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.00423342488216364
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.2531988099729756
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.04694300716659008
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00031590758363613365
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.32855119534321264
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.11802567471735012
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0010006750358637483
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0901351580973778
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 8.345771516728265e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.078003530179743e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0001978530213911813
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.464228050026216e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.5552766607616023e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.060956861543321e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.2941867825324396
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.156510308209689
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.757749165183952
+    }
+  ],
+  "p1cd5defe": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 231.81709407923327
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 5.796739126782091e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.535957900883827e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 4.687799350075957e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -52.216419803841724
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -57.144251492626054
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -61.7035774930251
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.5390445745380983e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.4162518019426431e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.003429894339997722
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.1692295404056592
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.002672699268561085
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.872638919448932
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0004877473072700722
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.8109154224803446
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.027790427397134027
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005651757794857418
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.7907871500913987
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.09221092103610148
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.004852361385509228
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0333146098714971
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00012990106003020268
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0757655960804841e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0001308186023531667
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00012417326540866287
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 8.7491623312669e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.7155811689645674e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.506995887985103
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.6996433232500223
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.941076878380217
+    }
+  ],
+  "p238d51d1": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 193.78369741784783
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 2.9235886394206025e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 5.762207062699177e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 4.726088050313856e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -63.41056926963998
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -55.02409164513228
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -61.49126478820329
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 4.580819694550943e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1510130494277939e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.005096799268973774
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.14034800710702547
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.003008135988671582
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.9033980367225327
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0019582659599972894
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.04609415723180735
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03997978832243735
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.2068115980370267e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.042346791736288164
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.055281948257842994
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.004317420120407321
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.053331706997149134
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0001300830772074299
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.8691596326172098e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0001646551220673128
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00014449360325965072
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00018715505192756229
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.196132051825392e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.169916415170221
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.264132469050038
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.899808267726857
+    }
+  ],
+  "p266c7fb8": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 209.11599365165858
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 8.637866043859393e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.197973938911308e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 1.639326288689838e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -56.26494348541581
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -62.11441805529206
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -63.65815545000523
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.348118329268998e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.24661222205305e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.003326070932844832
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.7715000369453321
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0030954068856757578
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8333693715790671
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0014658388027026974
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.8521900124315837
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.036258804353726866
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005678027896696057
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.041695756091508225
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.06765139891281721
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.005889228843314402
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.1078344892193629
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.000221587824379e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.235820906548204e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002972257619366535
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0001001273416561529
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.6671376269042372e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.2680536546836315e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.755894255191077
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.637881839597492
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.97401496009041
+    }
+  ],
+  "p272f9557": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 161.72209376731305
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.401462547157162e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 5.757930754552223e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 2.2859029577670155e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -63.93966494262719
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -51.48247925009903
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -62.95927042592041
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.938005325257127e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.235476782767892e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.002828213348991185
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.20764415879555928
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.002446186986838229
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0808953448964307
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0007063588706361751
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.6756726194912508
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.031724846965894525
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0004068060337468962
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.011266628919135727
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.1498374925350874
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0030649336877758932
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.05840771246313999
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002269140490674832
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.6247905565216034e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 8.719441908776847e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.416526849399812e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00011925314048162022
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.4467383318984896e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.195129593044268
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.8599997665889005
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.871648831685337
+    }
+  ],
+  "p295c50fd": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 174.06630671340744
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 1.8868562868992476e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.359074526609173e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 5.324560677194041e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -51.33272348163413
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -60.3043102635609
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -63.25919853052243
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.2072056584245579e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.177998286864517e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0020887311055646416
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.7518225834778763
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0025567050175466233
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8356233187561414
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.004301680671115705
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.7840416819901397
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0396580489455805
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00041189205315068114
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0011923782061789995
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.07840837600739936
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0025215390321394427
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.04083136616970007
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.000172727699241362
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.9135542171161053e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002853480421352556
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.92263843017311e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 8.457707019650924e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.6956857300058836e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.8348721547960483
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.7931943075011154
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.929605114409878
+    }
+  ],
+  "p2ecc7334": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 216.49322084101215
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 2.970473136259231e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 1.3156707260667564e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 1.0899433553568706e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -52.195252925297794
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -54.98939709378788
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -53.649583397513744
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.83785299195183e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.344411683626742e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.004477410021782247
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.2545644683239969
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0023470774235224605
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8697496464943506
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0024399664781545117
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.8384982830533437
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.027285279059788954
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00046427353826494056
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.07856182207362594
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.115996491858852
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.005471007811121647
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.018003978189204482
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00018905601337612584
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.6466608841556782e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0003422400281951232
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.016787968877389e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.3986136283503177e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.553473454419172e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.246582159126737
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.910361563842829
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.210508710086246
+    }
+  ],
+  "p3011abd8": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 177.26067487719732
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.00359048150204e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 1.1808037904942664e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 3.47649523551209e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -58.928408207290786
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -60.201358948392446
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -58.95088003378417
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.7002481225185036e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.007119814012947e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0006955288069174008
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.4962038101406397
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0018928648449763141
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.9071200217386012
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.007985172747546516
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.47253164973608375
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.057678487162118736
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0003584061822460628
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.28795248193821005
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0833751191492564
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0015189820317416643
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.03489841979667767
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 6.166808186507615e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.365118856363315e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0004867064304291735
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.078167853707455e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.6215922821253437e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.006178038920729e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.4834139245954754
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.776694110563395
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.952223435602309
+    }
+  ],
+  "p3762fe01": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 239.4844289280548
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 5.7780879676859695e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 1.702516314470078e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 5.507211259295937e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -55.54203026544929
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -50.2581877353665
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -51.301508464344174
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.0295616165934917e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.0117131245566683e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.004013591515881199
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.2596431217422932
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0036388439205302194
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0164936680445322
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0015819795247434699
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.37494765609997954
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0653120501861458
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00020623676759455012
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.18286082797962805
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.08872135350964039
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0006787489268166311
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.3189132158031902
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 4.717765758525127e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.314030933207086e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00015983338471558275
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1532699845868924e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.288164226131608e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.0609154055754106e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.900937238802539
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.588833060923693
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.2126356210373785
+    }
+  ],
+  "p3832aa3a": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 153.71370353547866
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 4.047738053754601e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.810204257887845e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 7.320543649412045e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -61.277483687876526
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -63.026073853421444
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -53.97634165466346
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 8.892329798095484e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.2753654146692465e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002623849559315408
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.2300743721046564
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0013727984809215543
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.3962997212949229
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0008968580139010508
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 1.1392944959977107
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.057759780881637725
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00016480357546550775
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.63087319224479
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.08178352215032778
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005002652301138574
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.2018223097723821
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00014139194072054694
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.0471041637420682e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002529226777835903
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.4063017207722738e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 5.079131371853354e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.955088074241099e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.362184724536748
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.589437851914476
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.986709070348741
+    }
+  ],
+  "p3900bef0": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 219.88203214603948
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 4.429372599507232e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.1358094383190544e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 2.542458106071652e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -51.07273089920358
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -51.36507910269975
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -63.49150652494091
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.1444277843568508e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1333185594679612e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0021519285234675653
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.6996179932607756
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0036204691674715335
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.7737464054458136
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.00332972177300941
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.03128130519813268
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0531352550441991
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.746620736948345e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.007691247054120016
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.07896788143137431
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.003147468939791745
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.2643302747825632
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.551911512812685e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.8065117081910774e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00021089971022236062
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.750945132080978e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 6.0619716351132164e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.098642348854787e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.033998753544455
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.689472852724012
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.955568661963334
+    }
+  ],
+  "p3c6b5232": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 235.68584612109942
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.505464096946875e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.2619528868122227e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 1.6260570535180068e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -63.69223269360247
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -51.68153089333344
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -54.34698615410198
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.6231883669241736e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1349846862176738e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.004408826303328935
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.24548299496141915
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0015284185238058396
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.9743150008554627
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0047123465944475485
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.7102070419639162
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.02396947538271544
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005445302718583106
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.3764707926816472
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.18608628839230135
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005927008056279759
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.07476457214560134
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002423384719803278
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1404859383267543e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.505404293721551e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.881775317400968e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.5952539584264966e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.6367713773365356e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.0187018346383576
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.9384696606531726
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.846123819728993
+    }
+  ],
+  "p3f21fd29": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 204.92960332898238
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 2.5162888577899858e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.010421622008487e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 4.685275621384098e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -64.16742831149568
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -62.29423313455909
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -63.02389870940752
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.9493745748431046e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.4778798321529316e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00351126558858331
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.23686060239347703
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00313954248953957
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8186677123677062
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0031049662581791636
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.24195530674073956
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.037068464761187664
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0006366575629958222
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.32712402358246406
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.05901838646959478
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0016258656819380989
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.011004979726182047
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002923113205658152
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.2568655645617684e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00020867110926875313
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.954655545326894e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.1474537013722416e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.920800373709121e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.870768825330431
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.917987013622582
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.852496235207445
+    }
+  ],
+  "p3f9dfe00": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 238.24252463034895
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 1.8151373511541313e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 1.8870313675191303e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 3.1999683876734857e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -50.12488055419261
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -61.19545539621967
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -62.64682064154896
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.0911463283164347e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.3288672022006437e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0011046575211057482
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.23332991154111626
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.002742629818062034
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8854832701002231
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0065672153730336
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.400871337583862
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.05351294663705183
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00020793111367390692
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.5516140510279098
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0777405725579994
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0010148311953175834
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.21841705604885822
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.471257433151794e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.3206322052697228e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0003835763423211719
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 9.008366044767562e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.714530663161207e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.004838163567653e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.419039549764532
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.678542930189005
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.995197469741035
+    }
+  ],
+  "p413c8889": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 208.42513962345717
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.6282449714680205e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.935746275356186e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 2.636945508405867e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -57.979586822835664
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -57.510496418567165
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -57.33468651952996
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 5.34125147277437e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.322302290536839e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.003421749281948434
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.7233412257952645
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0027753105470510477
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.7065861683270245
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0006452480616105115
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.2783664512897275
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03801065029295416
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00048053059800709806
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.09138449098979977
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.11088387313960421
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005493921854154409
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.1857578086323246
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002586402805907178
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.9864877232406038e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0001141126009344704
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00014213752457561637
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 8.74552709583313e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.3790513893299004e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.4819312841310395
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.7778472552110363
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.994625454125548
+    }
+  ],
+  "p426a988e": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 245.55283886577692
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 7.729568243215903e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.2799992463636287e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 6.70448416191253e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -54.12798313238953
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -50.36572250596699
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -60.1588080426228
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 9.474496251903907e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0280569983434704e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.005834233140776722
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.5406841215945414
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0019109491897194603
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.9060652529715595
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0008291412856904299
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.03485929686491602
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.033127671200490455
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0004500643522649261
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.26745910120653504
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.13432838038471537
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.004632817847512223
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.010386008228353158
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002702182871537082
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.686567230136421e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00025801476717493766
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.207806740020789e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 5.213615020129506e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.287558895549913e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.564511563281396
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.506240803189649
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.814857635305605
+    }
+  ],
+  "p47d379ce": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 242.42672896145743
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 4.898876219464227e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 1.9377952178165497e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 1.8619601006343426e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -55.01557654673226
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -59.98991165941392
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -52.60125717247327
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.356062832065951e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.7462133373767654e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.003711936305001542
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.5341567558920549
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.003921859693670682
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.5853589731218372
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.006911028006997994
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.2917893327928624
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03996895818766068
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00040528433447524384
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.10870903578495121
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.13458064716706525
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005963391419059349
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.012122611648043787
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00010530746693127019
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.932446753806756e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00015791813550977764
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00013295326911610394
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.958750890324405e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.435641515311738e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.0827413329389755
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.2707445431558146
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.9255304992100255
+    }
+  ],
+  "p4d93b0c3": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 205.5071924222691
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 5.312833102487853e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.528266263160924e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 4.665490809464613e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -51.89386266773975
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -52.515573643386574
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -60.90167105657953
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 4.757696644632377e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 9.313908660626442e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.003185499641657855
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.2153012962989918
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0015900920264030295
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0172857487284606
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.002923724394709657
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.6327420043880476
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03094413766636859
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0006540451078200434
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.70884438458241
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.16415138490371295
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005000313747367297
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.041107161855476276
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.712946597075898e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.3769125797719807e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00045255088606203345
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.384772131269055e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.26017331007811e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.7605171423458694e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.504679794565409
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.6996433232500223
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.794533332572412
+    }
+  ],
+  "p53b70df2": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 166.99094425053045
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 6.238949366576495e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.0738531344797564e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 2.206962285626051e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -58.328300705850864
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -59.69458185350483
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -55.67259611090441
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.3242397289333012e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.324673541277788e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.001887346259135842
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.6375649727016094
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0021434283605584275
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8548898599586403
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.005242952789780568
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.6060866813476872
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.02834566411232433
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005503794139811539
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.039004005161798826
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.2040262571789958
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005569888035591884
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.09004088498125627
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00010734673675379312
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.9354649961844428e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.000487067878005804
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.9088150841412e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.812358929476095e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.0451445692641217e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.2488101481203375
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.308137689007586
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.868065626415208
+    }
+  ],
+  "p54dfea77": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 249.7530875160484
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 1.325432302634216e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 2.765782564633531e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 1.6288449457067968e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -61.34684559000189
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -64.5252081251757
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -50.991323647905396
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.241703289296832e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.254100346073058e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0032648075747005634
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.3042794948400466
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.003923208138024428
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.7246863432489115
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0037165597966035374
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.14089027101185495
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03787191035471798
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00037553415237502087
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.05127409191153495
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.06307903743134805
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.004094782554433689
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.041479767262105637
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 6.694497559445707e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.4039112408810316e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 6.203021139030961e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00010953214530549146
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.7786622200499858e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.392446551550593e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.756468719307047
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.5642532853739888
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.966134853669761
+    }
+  ],
+  "p607c0a42": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 236.06329450008857
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 2.961570538152765e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.4160442508264295e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 4.553744124818341e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -56.225723795616155
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -57.78233930429548
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -64.14387350730064
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 8.3065670692857e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.158194204585139e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.000904809484451466
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.4391701632117695
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.001818490869394217
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.7821212173834065
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.005800126488463781
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.13566280468194147
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0398801499093925
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0006199494059392198
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.397541304774491
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.09713065549704303
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005023246876278342
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0200541455782954
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00023064130378191167
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 9.561400073508419e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0003670255246403728
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.998042045124265e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.550440225593396e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.762291255187913e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.1430405737510223
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.7487267291888466
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.667416315360419
+    }
+  ],
+  "p664ecb6e": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 236.0278583108997
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 1.8471915630514548e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.1534886481996303e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 6.481561450233266e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -64.79173040830352
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -56.05931515919512
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -50.098371155256366
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.7343859986442034e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.006046622979112e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0010501773370998524
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.5221673113594366
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.002602551204049953
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8489016781375875
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.004679827288558785
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.39690055570195026
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.039385565148753736
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.000665863248158361
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.21647271353994507
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.08970935983505055
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0010607060258668267
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.15536454747445233
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00020917764768004122
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.8829499387205805e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00031343121828510313
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.951589143702572e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 6.296038920888227e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.662254936093092e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.0675171980553895
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.021163339056628
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.928941098293765
+    }
+  ],
+  "p70874b2a": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 245.75284079316188
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 2.9431216120679095e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 8.018925628191696e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 5.42441523940474e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -57.300758896723835
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -61.65435471491018
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -57.789311113176026
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.658069654654567e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.5679157784484126e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0007358854270357645
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.4581984566025348
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0021383325233764005
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.9089984402381881
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.009611910487140734
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.4380138835236888
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.05894112753367652
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00043291033614506176
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.3860938491394503
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.10580322930946727
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0010433559137212388
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.1180593881639008
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.611883712019207e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.2879282808948582e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.094315100534168e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.009678286444279e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 5.058901192838197e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.007377370385161e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.1804610621839458
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.323380838664491
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.933845783345152
+    }
+  ],
+  "p733ec61e": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 243.29089163779108
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 4.667467805309481e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.455984167191863e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 8.704735034151607e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -58.593516511998494
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -53.31558679427141
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -63.74883269551408
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 9.534613062999267e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1160124050438835e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.004568816402274764
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.011213188448117636
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00211474475183274
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.966704186437342
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.002806847860603429
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.5157382229264638
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.035461960870354206
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.825041288737908e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.47526217883321076
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.01819975123872751
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00938224425001414
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.011789855422834861
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.920250234584804e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.9790019957297984e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0003408746403468439
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.44305097246642e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 9.050070005782066e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.25367770462866e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.9090255703728434
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.041962097873483
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.821754501267114
+    }
+  ],
+  "p793a3d75": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 233.27524117644265
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 7.940745665094356e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.225308518727709e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 6.579879393862628e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -58.764627752232286
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -52.759693828728004
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -59.02319464564716
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.6757187525107487e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 9.458477949164466e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0024671059532274113
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.014039009374744262
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0035499015062385505
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.7751144558557123
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.004926676621124091
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0703404487507484
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.041974296919957015
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0003020655938379465
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.08596573995194601
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.06045468003901193
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.006425887219031761
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.01879603913966477
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.000277614702054179
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.128742682194442e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00043287994358593985
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.000105375640979571
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.241389692477458e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.0096017486162315e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.329110585006699
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.033583662732729
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.839074280802627
+    }
+  ],
+  "p7e8d7d6f": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 211.97127046824573
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 1.5426733076499537e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.647525249188172e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 4.918001923750471e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -57.71824563296288
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -50.98693591765684
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -52.97655267568977
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.7508785341962122e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.000212934325115e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.004891659626897452
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.6982566312242874
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0010051612411152541
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.9775733743736108
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0017572691423282671
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.8735780010301352
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.032270485854828404
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.754944445588992e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.06362960359032308
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.10093258610331673
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0062247646801114566
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.01377427634433942
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 4.27308183114565e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.8512453860130757e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00022139292222584593
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.809139191838591e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.031048369997384e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.81938012009519e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.937317245883486
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.214119715830105
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.860805559790191
+    }
+  ],
+  "p881c7f54": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 192.1314421051553
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 4.7434451933563266e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 2.4424119529141585e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 2.0012411219039874e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -50.982908367521915
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -61.55909969179951
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -50.53445480431421
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.1284611729079334e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.0433990346994945e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00027932031576048737
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.04392882429019579
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0016323744786670025
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8711422678383155
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.004303950672327984
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.11062351104484575
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.023685096311372427
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.000565865814058391
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.279102706108537
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.152653829840793
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.004450467242207155
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.010568458006312636
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.751555664685602e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.108605020473204e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0001872147805925779
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00013882866133457095
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.7059705847432657e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.296577331945383e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.9555771729350018
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.081047217136987
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.694221145879086
+    }
+  ],
+  "p8b1585a0": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 162.5169566086368
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 1.682982366347911e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.238546633468376e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 5.003479458140164e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -60.63170482442454
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -57.01959443847233
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -51.48516747365744
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.2602837160013946e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.557746596357438e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.005155066492156156
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.4000610713582119
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.003158643527951664
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8683453665335238
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.002219712918781816
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.8175715127416003
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03872518179280909
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0006183678974972455
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.042877378700417496
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.19686852988964954
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005033262013470278
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.13182486544204472
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00013546276275265025
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.3836360839448557e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00021191484135023642
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00010522985673812728
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.71304606142003e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.422550196551517e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.66097378222459
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.7445791954260974
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.992763409116858
+    }
+  ],
+  "p8bcdee47": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 249.03218550202664
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 5.016024767535336e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.828547879589919e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 8.526867223846131e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -62.4484747077091
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -63.88626113558711
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -60.23875750229095
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 5.406437850731641e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.1158465273718043e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.005084665968846306
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.12202396841424228
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.001875469694994828
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.218011812115499
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.006808196231262719
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.14776236274636906
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.059911252768913605
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00023533747859491694
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.7076174486426894
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.10430401004225581
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00488363570807552
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.04764697663217124
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.2601035782695295e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.865153914412216e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.000425327051019381
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 9.724113907109179e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.6530238234611654e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.56212456012246e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.9378256086476813
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.716334274440528
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.882302077002053
+    }
+  ],
+  "p973cbb84": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 209.68132883250303
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 4.640701711988634e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 1.074337941246913e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 2.9576865358341564e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -61.27355200568813
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -56.88501991301351
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -62.64767331652581
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.166342253293483e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.389711601961898e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0005477910914731938
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.1474003187701044
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.002986912921929559
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.9289660741729003
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.004370847048216871
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.5883729931103099
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0372584877521146
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0006488464578906942
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.07416727825274431
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.1797365934966424
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005668936990323852
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.01032640371626596
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.727053570071783e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.5232102919383368e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 6.258193945489443e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.802292001775548e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.364092279720513e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.648267556022183e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.950417930439239
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.361245654310595
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.933255132470486
+    }
+  ],
+  "p9f9c331a": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 248.58433057762022
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.770634593627686e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 1.0495454893544022e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 1.3072402370219923e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -55.21037454414803
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -59.0624145845982
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -64.81120282138018
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 9.097889180102015e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.5704013337889333e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0049144637257757485
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.5557055213870611
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0018278336222091734
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8095997443450221
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0019399960279598949
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.920507226694308
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03983263663164318
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005047315289250975
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.12370108537707544
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.10056248898149006
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005113034870659995
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.010565118846810972
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00014770089795565123
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.4693176600560782e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0003085521804373559
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.346637975475869e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.0415681740311613e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.241949547771107e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.722834863796742
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.2896944763410465
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.974374183722759
+    }
+  ],
+  "paf75a0ec": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 218.14488916185
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 8.090348887766636e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 6.243325846923136e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 1.2465375181724995e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -64.95606493817044
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -50.87457186943515
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -63.04736174691005
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.540918443598773e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.821838000707072e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.004618270633021794
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03546277162843536
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.003520723890640903
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.9962698838513782
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.009978237678363967
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.2892433919435051
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.027187654632644283
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.818901329536638e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.24601374852935182
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.07614668950451581
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.002478955382898952
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0555272354075894
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 8.990515072629695e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.2476566081752982e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00010676328197911651
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.0177888210667075e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 5.187778594501607e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.13422939752369e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.466531966838427
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.700741290274458
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.666905671424436
+    }
+  ],
+  "pb5a5193d": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 143.3289296266067
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.378950065481207e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 5.778776319952232e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 3.797924806832736e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -61.65181828119879
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -50.60614063895329
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -58.963362597634514
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.4898399724161594e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.239408517748739e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00443600204147279
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.6017552512220897
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0006463689743233368
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0867943077647764
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.002764020531660078
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.6859753053193588
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.018944541035276173
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00026028496632011274
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.24267214475191412
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.12581476385323553
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.008227991974868764
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.03423515693353614
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 9.069947922922382e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.8232290104964158e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002292660515884468
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.458330726181077e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 6.320994152336135e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.8119347842018735e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.2193725046427737
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.172636669708528
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.494148970185661
+    }
+  ],
+  "pb7358f32": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 199.59462689608762
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.771932809480327e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.3600388677056044e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 3.282099367283364e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -53.19084468500866
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -61.8578637200145
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -54.140774111855066
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.2159213959935132e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1729258187481597e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.004703455243925883
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.6556691004532577
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0037133538627422986
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.7284177128876219
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.005331358329824348
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.5192571494328765
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03657368510998042
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005851193377170639
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.05917687011243353
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.11929217254039094
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00050185310987465
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.09190209912193674
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00011782298884816233
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.2736958866843783e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00032858104159496797
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.3163714675940666e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.784506848786585e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.888804073690864e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.5625479310235186
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.802052627525108
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.9014413534180905
+    }
+  ],
+  "pb823efb9": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 217.1627248640853
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 4.244929642402819e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 6.3271960646659605e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 2.1770755594342287e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -53.77345792859441
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -55.28625226401164
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -56.399454884198384
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.8961555709018996e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.0380659656944676e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0021426188640218317
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.5127723647633885
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0018703370662527452
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1919836336587097
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0005821933766462697
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.6612937683910253
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.023314732333366426
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00042309790817610115
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.2767246825510667
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.18085380572140625
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.005084234864489817
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0160710512127541
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0001717341719519311
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.7366106845292765e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.000225204761900617
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.043774422691839e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.104425012174468e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.676687050477824e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.9876046043431277
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.5297164320913073
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.217250943353138
+    }
+  ],
+  "pb8351fef": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 209.1082253484168
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 4.777293939120539e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.028667495745563e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 2.705247151634762e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -61.58699930634991
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -58.051505883849636
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -50.01388024294325
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 4.721576525126374e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.120609544763178e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.005283853586837925
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.20753259367811494
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0019321079805675002
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.3468582135252942
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.006857194598662837
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.8503459949123735
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.06756429563505836
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0003080462519655259
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.24168227122707156
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.10183426445007851
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0008123890907023007
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.38371822701242453
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00012496798271869168
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.9123243460264898e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0004835243932648164
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.5997195573298225e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.7692082122104984e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.32573878602809e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.821665211764723
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.684342860332896
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.781102763712581
+    }
+  ],
+  "pbae91695": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 147.07277481428935
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 1.0846092934948414e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.216083833836945e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 4.061868132823717e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -56.518364099980076
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -53.12613721050264
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -51.87508937286412
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 4.224361399183333e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.909654320665866e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.004926450223914439
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.750346947796477
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0026726697280032704
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0088640973344294
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.004477445000835453
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.9741510435804684
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0293075599924432
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00029000333762424334
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.07022801901400588
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.09049208460156426
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.008116317806845694
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0734297224784124
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00010671533190084022
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.7549518153714115e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00040427265759250135
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.223355820951823e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.158303385031942e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.997838919953108e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.715518229904751
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.157881859566984
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.463772972066978
+    }
+  ],
+  "pbd0a2290": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 151.5414500542467
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 7.317348365733747e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.803664600280464e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 9.238635223293165e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -54.44375263008253
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -60.43640214451924
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -57.936007684360355
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.4840818275441692e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.6987709886497945e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0009711550579565005
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.43525160586508865
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0013727984809215543
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.3917476750946003
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0006089664842925053
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 1.095260891078238
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.043298399441648844
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00017031421694623194
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.1705794605049383
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0853542990760757
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0036319341651896778
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.11392801877963131
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.000281787570702929
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.101912440453475e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0003841253915936684
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0028975121889681e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 5.711203763830356e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.673657296649505e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.993261065550262
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.849088151067789
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.997175816858487
+    }
+  ],
+  "pc2d8a8e6": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 240.3403268419063
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 2.4912078680953616e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 5.735942657690736e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 2.229041617948554e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -54.18525335363716
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -51.11204906642077
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -63.85933327537786
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.5720930379734943e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.4093245473031877e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0009946884894328435
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.07202765778892076
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0009223486060543683
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0582674176911697
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0035739284576329373
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.47327615987406624
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.02809853871539879
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.482789943169264e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.13932479991266325
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.16878157021479512
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.003331187481555806
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.03763238385613256
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 8.987047270750738e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.6005176075208788e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0003187168276075825
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.0186215879932566e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.371811531388458e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.698052461888896e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.9930880976814613
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.225898136785797
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.988448158001654
+    }
+  ],
+  "pcec5cf27": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 140.04813405191175
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.365076925328817e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.208293417197294e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 2.375244525181506e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -59.770599284430034
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -57.30516572343055
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -57.422850707816785
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.173744335910069e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 9.914256578866177e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0028682569726571857
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.3304699626526316
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.003066858646210989
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0134960183384762
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.005688434509082142
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.47809091434074835
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.016945111337537143
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0006063079134942886
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.11052717089797531
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.13330567016276212
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.004475768782474634
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.010778435633372448
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.698136939582106e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.100657115132586e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00022618885207658135
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00013398379357403012
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 6.278413517698845e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.096238398427484e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.419248895354235
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.7515436771136046
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.576500671147623
+    }
+  ],
+  "pd2ca4eaf": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 189.16578112875968
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 1.0754124274894497e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.0673570896045265e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 4.080310788062262e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -59.51874439506992
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -51.19286724146018
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -54.231358672798414
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 4.535012699556354e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 9.537523354305795e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0026766098050403867
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.48290569097136826
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0020257153215761737
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1699224135087227
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.005027540400301566
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.36491861630964695
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03371373454241298
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00020138668056037952
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.8989130376366874
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.012729363265733977
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.008809678557115173
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.04047351732099719
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00028575141265080106
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.5676079815600397e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00013110085470780062
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.004313063598955e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 6.373515431114219e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.039419511404722e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.6379046749616712
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.874449979890681
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.8525796942583534
+    }
+  ],
+  "pdc4da746": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 158.46068983204918
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 2.5331797677108154e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 5.084147376693514e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 3.0566162417120197e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -54.944993080500716
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -55.948300383777685
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -61.796728244010254
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.065726331976834e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.045808676126723e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00015266907862502275
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.5898606844216036
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.002295632898853408
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.885194675856526
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.003944960366425875
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.6397098160737706
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03908538205060942
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0002328795301513957
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.26843796221828825
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.14007491582554693
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.000541516205903076
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.05468025104207612
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 5.883888606308024e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.922996189159777e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.038508121761961e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.309220666071787e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 4.912149904479346e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 9.017822152840418e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.409283570644956
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.2135521167671106
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.920974668568739
+    }
+  ],
+  "pdd9466e2": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 248.3055725453828
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.1955040640472014e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.207819922548747e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 3.294841794775562e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -62.479810679210495
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -62.36473634538223
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -64.5229606945687
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.481641314130485e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.4650159958344181e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00013964679210602582
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.017158086889894605
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.004269278449121804
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.8342889314890003
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0023636513357812357
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.5623051871990516
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03429467031759474
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0005816290515307358
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.26467823919365846
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.08816433143547284
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0009649694682255397
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.013397406545001635
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002883233699019633
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.364657793205586e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002699887059287921
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.3983467559820005e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 5.599883581392195e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.149250718132517e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.504580407414203
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.3345219861936584
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.967290797933759
+    }
+  ],
+  "pe268b744": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 215.3823750840329
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 5.486033961723333e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.151574847286033e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 2.54485241691166e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -56.63438028823154
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -57.219371799406474
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -62.57631194956346
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.9919160279831505e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.162885343566659e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00048122174304864734
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.608273537282291
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0010214357952255454
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.9290969672417981
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0012426994620334392
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.8425795223056912
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03719710402734966
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0006936313684876706
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.005987979406005029
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.10531345554172106
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0007276655268118904
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.12632891151660647
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00010308149154479495
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.8780917516556582e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0004488789507713211
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 6.063195881785738e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.0840664928317238e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.490563503673785e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 2.985685687184372
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.200094866798016
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.973401832577189
+    }
+  ],
+  "pe2b0b6c2": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 236.3276246353828
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.592886685547875e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 5.198220855132171e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 1.0684100094586486e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -63.944856958260345
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -61.574100173403856
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -64.70596840531444
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 5.642692045775671e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.722874636603369e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.005992042647309974
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.25580836758178555
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0021135329617064393
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.9893556258493281
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.005361782934285277
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.5753726891635674
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.027198219541348986
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0006796568101108802
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.2663567384041597
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.09644987849167852
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.006862298559253169
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.04859593124796982
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0002228343054826654
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0505722088460623e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00020629178076852418
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00011128064278707044
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 3.5019311274750954e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 4.26704831945027e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.108630641843511
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.166134812520547
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.984738452407522
+    }
+  ],
+  "pe5eef847": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 148.20719006383885
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 2.5344205921502564e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 4.714143110281906e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 8.153680580687101e-07
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -52.36740750224596
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -53.9153452215797
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -50.21495965127834
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 9.695570692092593e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1068673021782574e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0030239863786351174
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.8498653189890477
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.001744943548452576
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.897994756915982
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.006621658300202202
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.17064107515047927
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.03043377167844748
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00017049652689548903
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0419356005923331
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.17041768143631125
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0013603899593371634
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.03152250643202818
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.835132639635039e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.426417138677814e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00011905099265513814
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.1246324111121e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 2.4826725569621762e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 7.170477390241508e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.5056288007303036
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.8191572191186927
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.749350526691023
+    }
+  ],
+  "pfa505758": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 237.717904827468
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 5.2209762619283945e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 3.5797542307335367e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 7.46779890446172e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -64.6676411978488
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -62.099423809509
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -54.11747590763021
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 1.0397891380779837e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.1363224168069096e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0034871193474999077
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.19759948960262183
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0034386601621204005
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.0446709749696557
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0010254579090168388
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 1.0429866240624575
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.06984364840778888
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0001161474152953279
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.2538700591169668
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.04586913370643004
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0023365649605742696
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.3380115773895607
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00015345468332640422
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.1453002053883494e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00035112947395971495
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.604588713077538e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 7.930170205049072e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 3.841848515480853e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.435120591681957
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.66494473140626
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.989249755235563
+    }
+  ],
+  "pfddd6423": [
+    {
+      "param_name": "celsius",
+      "type": "global",
+      "value": 35
+    },
+    {
+      "param_name": "v_init",
+      "type": "global",
+      "value": -84
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "cm",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 1
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ek",
+      "sectionlist": "all",
+      "type": "section",
+      "value": -100
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "ena",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 50
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "Ra",
+      "sectionlist": "all",
+      "type": "section",
+      "value": 204.79076349122244
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": 3.125626123990184e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": 6.020124935958089e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "g_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": 4.816770001764828e-06
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "somatic",
+      "type": "section",
+      "value": -60.08583115331678
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "basal",
+      "type": "section",
+      "value": -58.836241713043115
+    },
+    {
+      "dist_type": "uniform",
+      "param_name": "e_pas",
+      "sectionlist": "axonal",
+      "type": "section",
+      "value": -64.0204470153097
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 9.443778427566391e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "hd_lts",
+      "mech_param": "ghdbar",
+      "param_name": "ghdbar_hd_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 8.104457306152463e-07
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0008867998212908634
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.7920753745443823
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.001035031954936328
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.1034970488854507
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "na3_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_na3_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.0007104538678084676
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_naf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.7485879689973808
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.024803941093813685
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.00027649012346049124
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kdr_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.19158141125904382
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.14125429939765693
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 0.0023255609815144244
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "gkdrbar",
+      "param_name": "gbar_kaf_lts",
+      "sectionlist": "axonal",
+      "type": "range",
+      "value": 0.08123336504128985
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.00017228988423118903
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "im_lts",
+      "mech_param": "gkbar",
+      "param_name": "gkbar_im_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 1.4161364702094708e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 0.0004724382739564264
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "it_lts",
+      "mech_param": "gcabar",
+      "param_name": "gcabar_it_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 5.0588522879277424e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "somatic",
+      "type": "range",
+      "value": 8.5332338040763e-05
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kir23_lts",
+      "mech_param": "gbar",
+      "param_name": "gbar_kir23_lts",
+      "sectionlist": "basal",
+      "type": "range",
+      "value": 2.6226849627644127e-06
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "naf_lts",
+      "mech_param": "q",
+      "param_name": "q_naf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 3.372651265449332
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kaf_lts",
+      "mech_param": "q",
+      "param_name": "q_kaf_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.058126777554918
+    },
+    {
+      "dist_type": "uniform",
+      "mech": "kdr_lts",
+      "mech_param": "q",
+      "param_name": "q_kdr_lts",
+      "sectionlist": "all",
+      "type": "range",
+      "value": 4.289463138566104
+    }
+  ]
 }


### PR DESCRIPTION
14 LTS parameter sets removed from LTS_180118_morp_9862_updated_April2022 as they fall outside 3 SD of the experimental target cell. Remaining 51 models are verified consistent (shared parameter values unchanged, all morphologies present).