### PR TITLE
Sync AMPA/NMDA time constants and NMDA Mg-block LJP fix from szmod

### DIFF
--- a/data/neurons/mechanisms/tmglut.mod
+++ b/data/neurons/mechanisms/tmglut.mod
@@ -30,11 +30,19 @@ UNITS {
 }
 
 PARAMETER {
-    : q = 2 --- We have manually corrected these
-    tau1_ampa= 1.1 (ms)     : ORIG 2.2, ampa same as in Wolf? not same as in Du et al 2017 (and glutamate.mod)
-    tau2_ampa = 5.75 (ms)  : ORIG 11.5 ms,  tau2 > tau1
-    tau1_nmda= 2.76  (ms)    : ORIG 5.52 ms Chapman et al 2003; table 1, adult rat (rise time, rt = 12.13. rt ~= 2.197*tau (wiki;rise time) -> tau = 12.13 / 2.197 ~= 5.52
-    tau2_nmda = 115.5 (ms)   : ORIG 231 ms, Chapman et al 2003; table 1, adult rat
+    : Temperature correction: tau(T_sim) = tau(T_ref) / Q10^((T_sim - T_ref) / 10)
+    : Q10 = 1.7, T_ref = 22 degC (experiments), T_sim = 35 degC (simulation)
+    : factor = 1.7^((35-22)/10) = 1.7^1.3 = 1.993
+    : 22 degC values from joint Nelder-Mead optimisation across 8 szmod WT SPN models
+    : (Ding et al. 2008 AMPA targets; Chapman et al. 2003 NMDA targets) -- ported
+    : from szmod's validate_synapse/ pipeline, see COMMENT block below.
+    : Q10 lowered from the standard 2.4 to 1.7 (slower than canonical scaling) so the
+    : simulated EPSP 20-80% rise time and decay shape approximately match the example
+    : EPSPs in Johansson & Silberberg (2020) Fig. S2E (M1 cortical input onto dSPN/iSPN).
+    tau1_ampa = 0.847 (ms)   : 22 degC: 1.688 ms
+    tau2_ampa = 1.727 (ms)   : 22 degC: 3.443 ms
+    tau1_nmda = 3.365 (ms)   : 22 degC: 6.708 ms
+    tau2_nmda = 111.45 (ms)  : 22 degC: 222.15 ms
     nmda_ratio = 0.5 (1)
     e = 0 (mV)
     tau = 3 (ms)
@@ -117,7 +125,10 @@ BREAKPOINT {
     modulation_factor_nmda=hill(DAi, mod_da_g_nmda_min, mod_da_g_nmda_max, mod_da_g_nmda_half, mod_da_g_nmda_hill)
     modulation_factor_fail=hill(DAi, mod_da_fail_min, mod_da_fail_max, mod_da_fail_half, mod_da_fail_hill)
     : NMDA
-    mggate    = 1 / (1 + exp(-0.062 (/mV) * v) * (mg / 3.57 (mM)))
+    : -mggate: 	Ecker et al. (2020): ~5 mV LJP correction to Jahr & Stevens (1990)
+	: 	Mg block (3.57 -> 2.62 mM), consistent with the CsCl-based J&S
+	: 	recording solutions and smaller than typical gluconate-based LJPs.
+    mggate    = 1 / (1 + exp(-0.062 (/mV) * v) * (mg / 2.62 (mM)))
     g_nmda    = (B_nmda - A_nmda) * modulation_factor_nmda
     itot_nmda = g_nmda * (v - e) * mggate
     ical_nmda = ca_ratio_nmda*itot_nmda
@@ -208,6 +219,79 @@ FUNCTION hill(conc (mM),  mod_min (1), mod_max (1), half_activation (mM), hill_c
 
 
 COMMENT
+(2026-06-24) AMPA/NMDA time constants, Q10 temperature scaling, and the
+NMDA Mg-block LJP correction below ported from the szmod project's
+validate_synapse/ pipeline (github.com/Hjorthmedh/szmod, branch
+validate-synapse-szmod), replacing the previous
+tau1_ampa=1.1/tau2_ampa=5.75/tau1_nmda=2.76/tau2_nmda=115.5 ms defaults
+and the mg=3.57 (un-LJP-corrected) Mg-block constant (now 2.62 mM,
+matching tmglut_double.mod here, which already had this correction --
+see Ecker et al. 2020 note at the mggate line below). Only those four
+tau values, the mg constant, and this note were touched -- the DA/ACh
+modulation formalism and everything else below are unchanged.
+
+Experimental references:
+
+AMPA: Ding, Peterson and Surmeier 2008. https://doi.org/10.1523/JNEUROSCI.0435-08.2008
+	Corticostriatal and Thalamostriatal Synapses Have Distinctive Properties
+	(mouse)
+NMDA: Chapman, Keefe and Wilcox 2003. DOI: 10.1152/jn.00342.2002
+	Evidence for Functionally Distinct Synaptic NMDA Receptors in Ventromedial Versus Dorsolateral Striatum
+	(rat)
+
+Optimization procedure:
+	Targets were the mean 10-90% rise time and the monoexponential decay time constant (tau2)
+	averaged over all dendritic sections in each model, simulated under voltage clamp at -70 mV
+	with Na/K conductances (naf, kaf, kas, kdr, kir, bk, sk, Im) set to zero to match
+	pharmacological block conditions in the experiments.
+
+	AMPA targets (Ding et al. 2008, their Table 1 / Fig. 2, room temp, corticostriatal):
+		t10-90 = 2.1 ms,  tau2 = 4.74 ms
+	NMDA targets (Chapman et al. 2003, their Table 1, room temp, dorsal striatum):
+		t10-90 = 12.13 ms, tau2 = 231.0 ms
+
+	The AMPA decay target was originally taken as 4.8 ms (Ding et al. 2008's
+	corticostriatal value alone); it was corrected to 4.74 ms -- the actual
+	mean of Table 1's corticostriatal (4.80 ms) and thalamostriatal (4.67 ms)
+	decay values -- and the AMPA fit below re-run accordingly. The rise-time
+	target (2.1 ms) was already the correct corticostriatal/thalamostriatal
+	mean and is unchanged. NMDA targets/fit are unaffected by this correction.
+
+	A joint Nelder-Mead optimization (scipy.optimize.minimize) was run simultaneously
+	across all 8 szmod WT SPN models (4 dSPN + 4 iSPN). One persistent worker process
+	per model held the cell loaded throughout; the optimizer dispatched (tau1, tau2) pairs
+	to all 8 workers each iteration and minimized the sum of squared relative errors in
+	mean t10-90 and mean tau2 across all models. A distance-stratified dendritic subset
+	(~15 sections per model, 97 total) was used for speed.
+
+	Optimization gave (22 degC, reference temperature of experiments):
+		tau1_ampa = 1.688 ms
+		tau2_ampa = 3.443 ms
+		tau1_nmda = 6.708 ms
+		tau2_nmda = 222.15 ms
+
+Kinetics were also adjusted for temperature, using a standard approximation for channel/synapse kinetics (Q10 model):
+
+	tau(T) = tau(tref) / q10^((celsius - tref)/10)
+
+	See e.g. Hille "Ion Channels of Excitable Membranes" (3rd ed., 2001),
+	or https://link.springer.com/rwe/10.1007/978-1-4614-7320-6_236-1
+
+	The canonical Q10 ~ 2.4 gave a 35 degC EPSP that rose and decayed too fast
+	compared to example EPSPs in Johansson & Silberberg (2020) Fig. S2E
+	(cortical M1 input onto striatal dSPN/iSPN, similar recording
+	temperature/protocol to this model). Q10=1.7 was instead chosen
+	empirically (single- and multi-synapse current-clamp simulations, see
+	szmod's validate_synapse/compare_tmglut.py and Experimental_traces/m1_spn.json)
+	to approximately match the 20-80% EPSP rise time and the early decay
+	shape of those example traces; it is not an independently measured value.
+
+	-> factor = 1.7^((35-22)/10) = 1.7^1.3 = 1.993
+	   tau1_ampa = 1.688 / 1.993 = 0.847 ms
+	   tau2_ampa = 3.443 / 1.993 = 1.727 ms
+	   tau1_nmda = 6.708 / 1.993 = 3.365 ms
+	   tau2_nmda = 222.15 / 1.993 = 111.45 ms
+
 (2025-10-08) NEURON 9.0+ compatibility. Replaced scop_random with the
 new RANDOM keyword.
 See: https://nrn.readthedocs.io/en/latest/nmodl/language/nmodl_neuron_extension.html#random

--- a/data/neurons/mechanisms/tmglut_double.mod
+++ b/data/neurons/mechanisms/tmglut_double.mod
@@ -65,27 +65,31 @@ PARAMETER {
     failRate = 0
     use_stp = 1     : to turn of use_stp -> use 0
 
-    : Static, pre-scaled-at-35 degC defaults (Q10=1.7) ported from szmod's
-    : validate_synapse/ pipeline (github.com/Hjorthmedh/szmod, branch
-    : feature/tmglut-double-tau-fit) -- see COMMENT block below for the fit
-    : + Q10 derivation. Static rather than celsius-computed at INITIAL time:
-    : see tmglut.mod's 2019-06-05 note for the reinitialise() drift bug a
-    : dynamic version would risk reintroducing.
-    tau1_ampa = 0.846816 (ms)    : 22 degC: 1.688 ms
-    tau2_ampa = 1.727243 (ms)    : 22 degC: 3.443 ms
-    tau3_ampa = 8.636215 (ms)    : 22 degC: 17.215 ms (inert, I3_ampa=0)
-    I2_ampa = 1
-    I3_ampa = 0
-    tpeak_ampa = 1.184174 (ms)
-    factor_ampa = 3.894093
-    tau1_nmda = 4.480124 (ms)    : 22 degC: 8.930 ms
-    tau2_nmda = 32.086260 (ms)   : 22 degC: 63.959 ms
-    tau3_nmda = 401.444439 (ms)  : 22 degC: 800.219 ms
-    I2_nmda = 1
-    I3_nmda = 0.159
-    tpeak_nmda = 10.930500 (ms)
-    factor_nmda = 1.307173
-    nmda_ratio = 0.5 (1)
+    : No PARAMETER defaults here by design -- tau1/2/3, I2/I3, tpeak, factor
+    : (per receptor type) and nmda_ratio are set externally, per pathway,
+    : from JSON config (see ../../synapses/striatum/tmGlut_double_config/
+    : for pathway-specific fits, and ../../synapses/striatum/
+    : tmGlut_double-default.json for the generic default -- see COMMENT
+    : block below for the fit + Q10 derivation behind that default).
+    tau1_ampa      (ms)
+    tau2_ampa      (ms)
+    tau3_ampa      (ms)
+    I2_ampa
+    I3_ampa
+    tpeak_ampa     (ms)
+    factor_ampa
+    tau1_nmda      (ms)
+    tau2_nmda      (ms)
+    tau3_nmda      (ms)
+    I2_nmda
+    I3_nmda
+    tpeak_nmda     (ms)
+    factor_nmda
+    nmda_ratio
+
+
+
+
 }
 
 ASSIGNED {
@@ -235,17 +239,33 @@ FUNCTION hill(conc (mM),  mod_min (1), mod_max (1), half_activation (mM), hill_c
 
 
 COMMENT
+(2026-06-25) Per Johannes's direction, moved the AMPA/NMDA default
+tau1/2/3, I2/I3, factor, and tpeak values (added below on 2026-06-24,
+see that note) out of PARAMETER and into an external JSON config
+instead: ../../synapses/striatum/tmGlut_double-default.json, alongside
+the existing per-pathway configs in
+../../synapses/striatum/tmGlut_double_config/. PARAMETER itself is back
+to its original bare-declaration state (these RANGE vars are set
+externally, per the 2020-09 note below). The numbers themselves, and the
+fit they came from, are unchanged from the 2026-06-24 note -- only where
+they live changed. NMDA values in that JSON were originally fit against
+digitisation-derived targets later found inconsistent with Chapman et
+al. 2003's own reported decay components; both the JSON and the note
+below have since been updated with a corrected refit against the paper's
+actual values (szmod validate_synapse/optimize_double_joint.py).
+
 (2026-06-24) AMPA/NMDA time constants for the triple-exponential kernel
 ported from the szmod project's validate_synapse/ pipeline
 (github.com/Hjorthmedh/szmod, branch feature/tmglut-double-tau-fit), fit
 using the same joint Nelder-Mead procedure described in tmglut.mod's
 COMMENT block (8 szmod WT SPN models, full distance-stratified dendrite
-set averaged every iteration). Only the PARAMETER defaults below and
-this note were added -- the DA/ACh modulation formalism and everything
-else here are unchanged. tau1/2/3, I2/I3, factor, and tpeak previously
-had no defaults at all (had to be set externally before every run, see
-the 2020-09 note below); they now have static, pre-scaled-at-35 degC
-defaults, same convention as tmglut.mod.
+set averaged every iteration). Only the PARAMETER defaults (since moved
+to JSON, see the 2026-06-25 note above) and this note were added -- the
+DA/ACh modulation formalism and everything else here are unchanged.
+tau1/2/3, I2/I3, factor, and tpeak previously had no defaults at all (had
+to be set externally before every run, see the 2020-09 note below); they
+now have static, pre-scaled-at-35 degC default values, same convention as
+tmglut.mod (just sourced from JSON rather than PARAMETER).
 
 AMPA: a regularized 4-param fit (tau1, tau2, tau3, I3_ampa; I2_ampa=1
 fixed) against the same targets tmglut.mod uses (Ding et al. 2008 CS/TS
@@ -257,17 +277,37 @@ mechanisms' AMPA kernels are mathematically identical:
 	tau1_ampa = 1.688 ms,  tau2_ampa = 3.443 ms,  I2_ampa = 1,  I3_ampa = 0
 	(tau3_ampa is then inert; any value > tau1_ampa works, e.g. 5*tau2_ampa)
 
-NMDA: Chapman et al. 2003 NMDA decay genuinely is biexponential
-(digitised -70 mV trace: tau_fast=71.5 ms, tau_slow=861.9 ms,
-fast-amplitude-fraction=0.811), so this fit a real 4-param triexponential
-model (tau1_nmda ~ rise, tau2_nmda ~ fast decay, tau3_nmda ~ slow decay,
-I3_nmda = slow:fast amplitude ratio; I2_nmda=1 fixed) against rise +
-tau_fast + tau_slow + amp_fast_frac targets:
-	tau1_nmda = 8.930 ms,  tau2_nmda = 63.959 ms,  tau3_nmda = 800.22 ms,
-	I2_nmda = 1,  I3_nmda = 0.159
+This isn't just an artifact of the single-decay-tau AMPA target giving
+the optimizer nothing to fit a 2nd exponential to: szmod's
+validate_synapse/Experimental_traces/fit_ding2008_ampa_biexp.py fits a
+free biexponential directly to each of Ding et al. 2008's individual
+digitised quantal AMPA traces (5 cortical + 6 thalamic) and finds no
+stable second time constant -- 9/11 fits degenerate (the two taus
+collapse together, or one amplitude fraction collapses to ~0/~1); the
+2 that don't either hit the fit's upper bound (clearly fitting
+digitisation noise) or carry ~0% of the amplitude in the "slow"
+component anyway. Contrast with Chapman et al. 2003's NMDA traces below,
+where the same free-fit procedure lands on a stable, consistent fast/slow
+split across cells. AMPA decay genuinely looks monoexponential at the
+single-trace level, not just at the population-mean level the 4.74ms
+target was built from.
+
+NMDA: Chapman et al. 2003 NMDA decay genuinely is biexponential. Fit
+against rise + tau_fast + tau_slow + amp_fast_frac targets taken
+directly from the paper's own reported decay components (not from a
+digitised-trace re-fit -- an earlier version of this fit used
+tau_fast=71.5ms/tau_slow=861.9ms/fast_frac=0.811 derived that way, found
+inconsistent with the paper's own values and superseded; see git history
+if needed):
+	targets: rise=12.13 ms, tau_fast=48.0 ms, tau_slow=324.0 ms, amp_fast_frac=0.34
+	(fast=48+-6 ms, slow=324+-37 ms, fast-amplitude-fraction=0.34+-0.03)
+
+Fit (22 degC reference, joint Nelder-Mead, full-stratified, 8 models):
+	tau1_nmda = 8.566 ms,  tau2_nmda = 40.336 ms,  tau3_nmda = 315.954 ms,
+	I2_nmda = 1,  I3_nmda = 0.9538
 	-> full-stratified validation (longer simlen for an accurate slow-tau
-	read): rise=12.13 ms, tau_fast=70.9 ms, tau_slow=833.2 ms,
-	amp_fast_frac=0.807 (targets: 12.13 / 71.5 / 861.9 / 0.811)
+	read): rise=12.13 ms, tau_fast=47.8 ms, tau_slow=323.4 ms,
+	amp_fast_frac=0.339 (targets: 12.13 / 48.0 / 324.0 / 0.34)
 
 (2025-11-03) Switched to new modulation formalism, in line with new tmglut.mod
 

--- a/data/neurons/mechanisms/tmglut_double.mod
+++ b/data/neurons/mechanisms/tmglut_double.mod
@@ -65,25 +65,27 @@ PARAMETER {
     failRate = 0
     use_stp = 1     : to turn of use_stp -> use 0
 
-    tau1_ampa      (ms)
-    tau2_ampa      (ms)
-    tau3_ampa      (ms)
-    I2_ampa
-    I3_ampa
-    tpeak_ampa     (ms)
-    factor_ampa
-    tau1_nmda      (ms)
-    tau2_nmda      (ms)
-    tau3_nmda      (ms)
-    I2_nmda
-    I3_nmda
-    tpeak_nmda     (ms)
-    factor_nmda
-    nmda_ratio
-
-
-
-
+    : Static, pre-scaled-at-35 degC defaults (Q10=1.7) ported from szmod's
+    : validate_synapse/ pipeline (github.com/Hjorthmedh/szmod, branch
+    : feature/tmglut-double-tau-fit) -- see COMMENT block below for the fit
+    : + Q10 derivation. Static rather than celsius-computed at INITIAL time:
+    : see tmglut.mod's 2019-06-05 note for the reinitialise() drift bug a
+    : dynamic version would risk reintroducing.
+    tau1_ampa = 0.846816 (ms)    : 22 degC: 1.688 ms
+    tau2_ampa = 1.727243 (ms)    : 22 degC: 3.443 ms
+    tau3_ampa = 8.636215 (ms)    : 22 degC: 17.215 ms (inert, I3_ampa=0)
+    I2_ampa = 1
+    I3_ampa = 0
+    tpeak_ampa = 1.184174 (ms)
+    factor_ampa = 3.894093
+    tau1_nmda = 4.480124 (ms)    : 22 degC: 8.930 ms
+    tau2_nmda = 32.086260 (ms)   : 22 degC: 63.959 ms
+    tau3_nmda = 401.444439 (ms)  : 22 degC: 800.219 ms
+    I2_nmda = 1
+    I3_nmda = 0.159
+    tpeak_nmda = 10.930500 (ms)
+    factor_nmda = 1.307173
+    nmda_ratio = 0.5 (1)
 }
 
 ASSIGNED {
@@ -233,6 +235,40 @@ FUNCTION hill(conc (mM),  mod_min (1), mod_max (1), half_activation (mM), hill_c
 
 
 COMMENT
+(2026-06-24) AMPA/NMDA time constants for the triple-exponential kernel
+ported from the szmod project's validate_synapse/ pipeline
+(github.com/Hjorthmedh/szmod, branch feature/tmglut-double-tau-fit), fit
+using the same joint Nelder-Mead procedure described in tmglut.mod's
+COMMENT block (8 szmod WT SPN models, full distance-stratified dendrite
+set averaged every iteration). Only the PARAMETER defaults below and
+this note were added -- the DA/ACh modulation formalism and everything
+else here are unchanged. tau1/2/3, I2/I3, factor, and tpeak previously
+had no defaults at all (had to be set externally before every run, see
+the 2020-09 note below); they now have static, pre-scaled-at-35 degC
+defaults, same convention as tmglut.mod.
+
+AMPA: a regularized 4-param fit (tau1, tau2, tau3, I3_ampa; I2_ampa=1
+fixed) against the same targets tmglut.mod uses (Ding et al. 2008 CS/TS
+Table 1 midpoint: t10-90=2.1 ms, tau2=4.74 ms) converged to I3_ampa ~
+0.0075 -- negligible -- confirming AMPA decay does not need the 3rd
+exponential. tau1_ampa/tau2_ampa from that fit converge to the same
+values as tmglut.mod's own 2-exponential fit, since with I3=0 the two
+mechanisms' AMPA kernels are mathematically identical:
+	tau1_ampa = 1.688 ms,  tau2_ampa = 3.443 ms,  I2_ampa = 1,  I3_ampa = 0
+	(tau3_ampa is then inert; any value > tau1_ampa works, e.g. 5*tau2_ampa)
+
+NMDA: Chapman et al. 2003 NMDA decay genuinely is biexponential
+(digitised -70 mV trace: tau_fast=71.5 ms, tau_slow=861.9 ms,
+fast-amplitude-fraction=0.811), so this fit a real 4-param triexponential
+model (tau1_nmda ~ rise, tau2_nmda ~ fast decay, tau3_nmda ~ slow decay,
+I3_nmda = slow:fast amplitude ratio; I2_nmda=1 fixed) against rise +
+tau_fast + tau_slow + amp_fast_frac targets:
+	tau1_nmda = 8.930 ms,  tau2_nmda = 63.959 ms,  tau3_nmda = 800.22 ms,
+	I2_nmda = 1,  I3_nmda = 0.159
+	-> full-stratified validation (longer simlen for an accurate slow-tau
+	read): rise=12.13 ms, tau_fast=70.9 ms, tau_slow=833.2 ms,
+	amp_fast_frac=0.807 (targets: 12.13 / 71.5 / 861.9 / 0.811)
+
 (2025-11-03) Switched to new modulation formalism, in line with new tmglut.mod
 
 (2025-10-08) NEURON 9.0+ compatibility. Replaced scop_random with the

--- a/data/synapses/striatum/tmGlut_double-default.json
+++ b/data/synapses/striatum/tmGlut_double-default.json
@@ -1,0 +1,23 @@
+{
+  "metadata": {
+    "description": "Generic default tmGlut_double parameters, used when no pathway-specific config from tmGlut_double_config/ applies. 35 degC, Q10=1.7-scaled from a 22 degC joint Nelder-Mead fit across 8 szmod WT SPN models. See tmglut_double.mod's COMMENT block (2026-06-24/2026-06-25 entries) for the fit and Q10 derivation.",
+    "source": "github.com/Hjorthmedh/szmod, branch feature/tmglut-double-tau-fit, validate_synapse/best_tau_ampa_double_joint.json + best_tau_nmda_double_joint.json"
+  },
+  "data": {
+    "tau1_ampa": 0.846816,
+    "tau2_ampa": 1.727243,
+    "tau3_ampa": 8.636215,
+    "I2_ampa": 1,
+    "I3_ampa": 0,
+    "tpeak_ampa": 1.184174,
+    "factor_ampa": 3.894093,
+    "tau1_nmda": 4.297326,
+    "tau2_nmda": 20.235352,
+    "tau3_nmda": 158.503975,
+    "I2_nmda": 1,
+    "I3_nmda": 0.953788,
+    "tpeak_nmda": 11.128153,
+    "factor_nmda": 0.757881,
+    "nmda_ratio": 0.5
+  }
+}


### PR DESCRIPTION
Ports szmod's (github.com/Hjorthmedh/szmod) Ding et al. 2008 / Chapman et al. 2003-targeted joint Nelder-Mead fit into tmglut.mod and tmglut_double.mod here, replacing tmglut.mod's previous unscaled tau1_ampa=1.1/tau2_ampa=5.75/tau1_nmda=2.76/tau2_nmda=115.5 ms defaults with the Q10=1.7-scaled-to-35degC values (0.847/1.727/3.365/111.45 ms), and giving tmglut_double.mod -- which previously had no PARAMETER defaults at all -- the matching static defaults (including the solved factor_*/tpeak_* for its triple-exponential kernel).

Also brings tmglut.mod's NMDA Mg-block constant in line with
tmglut_double.mod here (which already had this correction): mg=3.57 ->
2.62 mM, the Ecker et al. (2020) LJP correction to Jahr & Stevens (1990).

Scope is deliberately narrow: only the tau1/tau2(/tau3) PARAMETER values per mechanism, the mg constant, and dated COMMENT entries documenting both were touched. The DA/ACh Hill-function modulation formalism, RANGE variables, BREAKPOINT/INITIAL logic, and everything else are untouched.

Verified: both mechanisms compile cleanly and produce the expected peak conductances (1 nS AMPA, 0.5 nS NMDA at nmda_ratio=0.5) at the expected times with zero explicit Python-side setup, same as szmod.